### PR TITLE
Fix reading UTF-16 RapidStart XML

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -131,7 +131,13 @@ function App() {
       try {
         logDebug('Loading starting data');
         const resp = await fetch('NAV27.0.US.ENU.STANDARD.xml');
-        const text = await resp.text();
+        let text: string;
+        try {
+          const buf = await resp.arrayBuffer();
+          text = new TextDecoder('utf-16').decode(buf);
+        } catch {
+          text = await resp.text();
+        }
         const parser = new DOMParser();
         const xmlDoc = parser.parseFromString(text, 'application/xml');
         const data = {


### PR DESCRIPTION
## Summary
- decode the starting NAV XML using UTF‑16 for accurate parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68775acb38cc8322981ad21269a6c475