### PR TITLE
Add configuration menu after splash screen

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 // Simple React app to guide users through Business Central setup
 const { useState, useEffect } = React;
 import HomePage from './pages/HomePage';
+import ConfigMenuPage from './pages/ConfigMenuPage';
 import CompanyInfoPage from './pages/CompanyInfoPage';
 import PostingGroupsPage from './pages/PostingGroupsPage';
 import PaymentTermsPage from './pages/PaymentTermsPage';
@@ -239,6 +240,14 @@ function App() {
       {step !== 0 && <h1>Business Central Setup</h1>}
       {step === 0 && <HomePage next={next} />}
       {step === 1 && (
+        <ConfigMenuPage
+          goToCompanyInfo={() => setStep(2)}
+          goToPostingGroups={() => setStep(3)}
+          goToPaymentTerms={() => setStep(4)}
+          back={back}
+        />
+      )}
+      {step === 2 && (
         <CompanyInfoPage
           fields={companyFields}
           commonFieldNames={commonFieldNames}
@@ -249,7 +258,7 @@ function App() {
           back={back}
         />
       )}
-      {step === 2 && (
+      {step === 3 && (
         <PostingGroupsPage
           formData={formData}
           handleChange={handleChange}
@@ -257,7 +266,7 @@ function App() {
           back={back}
         />
       )}
-      {step === 3 && (
+      {step === 4 && (
         <PaymentTermsPage
           formData={formData}
           handleChange={handleChange}
@@ -265,7 +274,7 @@ function App() {
           back={back}
         />
       )}
-      {step === 4 && (
+      {step === 5 && (
         <FinishPage
           generate={generateCustomRapidStart}
           back={back}

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface Props {
+  goToCompanyInfo: () => void;
+  goToPostingGroups: () => void;
+  goToPaymentTerms: () => void;
+  back: () => void;
+}
+
+function ConfigMenuPage({
+  goToCompanyInfo,
+  goToPostingGroups,
+  goToPaymentTerms,
+  back,
+}: Props) {
+  return (
+    <div>
+      <h2>Select a configuration area</h2>
+      <div className="menu-grid">
+        <div className="menu-box" onClick={goToCompanyInfo}>
+          <div className="icon" role="img" aria-label="Company">
+            🏢
+          </div>
+          <div>Company Information</div>
+        </div>
+        <div className="menu-box" onClick={goToPostingGroups}>
+          <div className="icon" role="img" aria-label="Posting Groups">
+            📦
+          </div>
+          <div>Posting Groups</div>
+        </div>
+        <div className="menu-box" onClick={goToPaymentTerms}>
+          <div className="icon" role="img" aria-label="Payment Terms">
+            💰
+          </div>
+          <div>Payment Terms</div>
+        </div>
+      </div>
+      <div className="nav">
+        <button onClick={back}>Back</button>
+      </div>
+    </div>
+  );
+}
+
+export default ConfigMenuPage;

--- a/style.css
+++ b/style.css
@@ -113,3 +113,30 @@ button:hover {
     margin-top: 20px;
   }
 }
+
+.menu-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  margin-top: 20px;
+}
+
+.menu-box {
+  flex: 1 1 150px;
+  background: #f3f2f1;
+  border: 1px solid #8a8886;
+  border-radius: 6px;
+  padding: 20px;
+  text-align: center;
+  cursor: pointer;
+  min-width: 150px;
+}
+
+.menu-box:hover {
+  background: #e1dfdd;
+}
+
+.menu-box .icon {
+  font-size: 2em;
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- insert a new configuration menu page that displays boxes for each setup section
- add styles for menu box layout
- integrate the new page in `App` so it appears after the splash screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68777884b3f08322a4822fb039e3dc44