### PR TITLE
Improve form layout

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -200,37 +200,42 @@ function App() {
         </select>
       );
     }
-    const showButton =
-      cf.recommended &&
-      suggestionFields.has(cf.field) &&
-      val !== recommendedCode(cf.recommended);
+    const acceptRecommended = () => {
+      setFormData((f: FormData) => ({
+        ...f,
+        [key]: recommendedCode(cf.recommended),
+      }));
+    };
+
+    const handleRecommended = () => {
+      if (cf.recommended) {
+        const rec = recommendedCode(cf.recommended);
+        if (window.confirm(`Suggested value: ${rec}. Use it?`)) {
+          acceptRecommended();
+        }
+      }
+    };
+
     return (
-      <div className="field" key={key}>
-        <label>
-          {cf.field}: {inputEl}
-        </label>
-        {showButton && (
-          <button
-            type="button"
-            onClick={() =>
-              setFormData((f: FormData) => ({
-                ...f,
-                [key]: recommendedCode(cf.recommended),
-              }))
-            }
-          >
-            Use suggested
-          </button>
-        )}
-        {cf.recommended && (
-          <div className="suggested">Suggested: {cf.recommended}</div>
-        )}
-        {cf.considerations && (
-          <details>
-            <summary>Considerations</summary>
-            <p>{cf.considerations}</p>
-          </details>
-        )}
+      <div className="field-row" key={key}>
+        <div className="field-name">{cf.field}</div>
+        <div className="field-input">
+          {inputEl}
+          {cf.recommended && (
+            <span
+              className="icon"
+              role="button"
+              title="Use recommended value"
+              onClick={handleRecommended}
+            >
+              ⭐
+            </span>
+          )}
+          <span className="icon" role="button" title="Ask AI">
+            🤖
+          </span>
+        </div>
+        <div className="field-considerations">{cf.considerations}</div>
       </div>
     );
   }

--- a/src/pages/PaymentTermsPage.tsx
+++ b/src/pages/PaymentTermsPage.tsx
@@ -9,10 +9,15 @@ function PaymentTermsPage({ formData, handleChange, next, back }: Props) {
   return (
     <div>
       <h2>Payment Terms</h2>
-      <label>
-        Terms:
-        <input name="paymentTerms" value={formData.paymentTerms || ''} onChange={handleChange} />
-      </label>
+      <div className="field-row">
+        <div className="field-name">Terms</div>
+        <div className="field-input">
+          <input name="paymentTerms" value={formData.paymentTerms || ''} onChange={handleChange} />
+          <span className="icon" role="button" title="Use recommended value">⭐</span>
+          <span className="icon" role="button" title="Ask AI">🤖</span>
+        </div>
+        <div className="field-considerations"></div>
+      </div>
       <div className="nav">
         <button onClick={back}>Back</button>
         <button onClick={next}>Next</button>

--- a/src/pages/PostingGroupsPage.tsx
+++ b/src/pages/PostingGroupsPage.tsx
@@ -9,10 +9,15 @@ function PostingGroupsPage({ formData, handleChange, next, back }: Props) {
   return (
     <div>
       <h2>Posting Groups</h2>
-      <label>
-        General Posting Group:
-        <input name="postingGroup" value={formData.postingGroup || ''} onChange={handleChange} />
-      </label>
+      <div className="field-row">
+        <div className="field-name">General Posting Group</div>
+        <div className="field-input">
+          <input name="postingGroup" value={formData.postingGroup || ''} onChange={handleChange} />
+          <span className="icon" role="button" title="Use recommended value">⭐</span>
+          <span className="icon" role="button" title="Ask AI">🤖</span>
+        </div>
+        <div className="field-considerations"></div>
+      </div>
       <div className="nav">
         <button onClick={back}>Back</button>
         <button onClick={next}>Next</button>

--- a/style.css
+++ b/style.css
@@ -140,3 +140,26 @@ button:hover {
   font-size: 2em;
   margin-bottom: 10px;
 }
+/* Layout for form fields */
+.field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 15px;
+}
+.field-name {
+  font-weight: bold;
+}
+.field-input {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.field-considerations {
+  font-size: 0.9em;
+  color: #555;
+}
+.icon {
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- update field layout to use three columns
- integrate recommended and AI icons with confirm popup
- adapt posting groups and payment terms pages to new layout
- add CSS styles for the new grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68777aa9091083228e4b673a22d839ca