### PR TITLE
Add Basic Info to menu with validation

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -3,6 +3,7 @@ export default {
   splashWelcome: 'Welcome! This wizard will help you configure Dynamics 365 Business Central.',
   getStarted: 'Get Started',
   basicInfoTitle: 'Basic Information',
+  basicInfo: 'Basic Information',
   companyNameLabel: 'Company Name',
   industryLabel: 'Industry',
   websiteLabel: 'Website URL',

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -87,6 +87,16 @@ function App() {
   }, []);
 
   useEffect(() => {
+    const nameKey = fieldKey('Company Name');
+    const siteKey = fieldKey('Company Website');
+    setFormData(f => ({
+      ...f,
+      [nameKey]: basicInfo.companyName || f[nameKey] || '',
+      [siteKey]: basicInfo.websiteUrl || f[siteKey] || '',
+    }));
+  }, [basicInfo]);
+
+  useEffect(() => {
     async function init() {
       try {
         logDebug('Loading config tables');
@@ -120,6 +130,12 @@ function App() {
     setFormData({ ...formData, [name]: value });
     if (name in basicInfo) {
       setBasicInfo({ ...basicInfo, [name as keyof BasicInfo]: value });
+    }
+  }
+
+  function handleBlur(e: any): void {
+    if (!e.target.checkValidity()) {
+      alert('Invalid value');
     }
   }
 
@@ -218,7 +234,12 @@ function App() {
   function renderField(cf: CompanyField) {
     const key = fieldKey(cf.field);
     const val = formData[key] || '';
-    let inputProps: any = { name: key, value: val, onChange: handleChange };
+    let inputProps: any = {
+      name: key,
+      value: val,
+      onChange: handleChange,
+      onBlur: handleBlur,
+    };
     if (/phone/i.test(cf.field)) {
       inputProps.type = 'tel';
       inputProps.pattern = '[0-9+()\- ]+';
@@ -312,19 +333,21 @@ function App() {
       {step !== 0 && <h1>{strings.appTitle}</h1>}
       {step === 0 && <HomePage next={next} />}
       {step === 1 && (
-        <BasicInfoPage
-          formData={basicInfo}
-          handleChange={handleChange}
-          next={next}
-          back={back}
-        />
-      )}
-      {step === 2 && (
         <ConfigMenuPage
+          goToBasicInfo={() => setStep(2)}
           goToCompanyInfo={() => setStep(3)}
           goToPostingGroups={() => setStep(4)}
           goToPaymentTerms={() => setStep(5)}
           back={back}
+        />
+      )}
+      {step === 2 && (
+        <BasicInfoPage
+          formData={basicInfo}
+          handleChange={handleChange}
+          handleBlur={handleBlur}
+          next={next}
+          back={() => setStep(1)}
         />
       )}
       {step === 3 && (
@@ -335,13 +358,14 @@ function App() {
           handleChange={handleChange}
           renderField={renderField}
           next={next}
-          back={back}
+          back={() => setStep(1)}
         />
       )}
       {step === 4 && (
         <PostingGroupsPage
           formData={formData}
           handleChange={handleChange}
+          handleBlur={handleBlur}
           next={next}
           back={back}
           askAI={openAIDialog}
@@ -351,6 +375,7 @@ function App() {
         <PaymentTermsPage
           formData={formData}
           handleChange={handleChange}
+          handleBlur={handleBlur}
           next={next}
           back={back}
           askAI={openAIDialog}

--- a/src/pages/BasicInfoPage.tsx
+++ b/src/pages/BasicInfoPage.tsx
@@ -4,6 +4,7 @@ import { BasicInfo } from '../types';
 interface Props {
   formData: BasicInfo;
   handleChange: (e: any) => void;
+  handleBlur: (e: any) => void;
   next: () => void;
   back: () => void;
 }
@@ -21,7 +22,13 @@ const industries = [
   'Government',
 ];
 
-function BasicInfoPage({ formData: data, handleChange, next, back }: Props) {
+function BasicInfoPage({
+  formData: data,
+  handleChange,
+  handleBlur,
+  next,
+  back,
+}: Props) {
   return (
     <div>
       <h2>{strings.basicInfoTitle}</h2>
@@ -32,6 +39,7 @@ function BasicInfoPage({ formData: data, handleChange, next, back }: Props) {
             name="companyName"
             value={data.companyName || ''}
             onChange={handleChange}
+            onBlur={handleBlur}
           />
         </div>
         <div className="field-considerations" />
@@ -44,6 +52,7 @@ function BasicInfoPage({ formData: data, handleChange, next, back }: Props) {
             name="industry"
             value={data.industry || ''}
             onChange={handleChange}
+            onBlur={handleBlur}
           />
           <datalist id="industry-list">
             {industries.map(ind => (
@@ -57,9 +66,11 @@ function BasicInfoPage({ formData: data, handleChange, next, back }: Props) {
         <div className="field-name">{strings.websiteLabel}</div>
         <div className="field-input">
           <input
+            type="url"
             name="websiteUrl"
             value={data.websiteUrl || ''}
             onChange={handleChange}
+            onBlur={handleBlur}
           />
         </div>
         <div className="field-considerations" />
@@ -72,6 +83,7 @@ function BasicInfoPage({ formData: data, handleChange, next, back }: Props) {
             rows={8}
             value={data.description || ''}
             onChange={handleChange}
+            onBlur={handleBlur}
           />
         </div>
         <div className="field-considerations">{strings.descriptionHint}</div>

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import strings from '../../res/strings';
 
 interface Props {
+  goToBasicInfo: () => void;
   goToCompanyInfo: () => void;
   goToPostingGroups: () => void;
   goToPaymentTerms: () => void;
@@ -9,6 +10,7 @@ interface Props {
 }
 
 function ConfigMenuPage({
+  goToBasicInfo,
   goToCompanyInfo,
   goToPostingGroups,
   goToPaymentTerms,
@@ -18,6 +20,12 @@ function ConfigMenuPage({
     <div>
       <h2>{strings.selectConfigArea}</h2>
       <div className="menu-grid">
+        <div className="menu-box" onClick={goToBasicInfo}>
+          <div className="icon" role="img" aria-label="Basic Info">
+            ℹ️
+          </div>
+          <div>{strings.basicInfo}</div>
+        </div>
         <div className="menu-box" onClick={goToCompanyInfo}>
           <div className="icon" role="img" aria-label="Company">
             🏢

--- a/src/pages/PaymentTermsPage.tsx
+++ b/src/pages/PaymentTermsPage.tsx
@@ -3,19 +3,32 @@ import strings from '../../res/strings';
 interface Props {
   formData: { [key: string]: any };
   handleChange: (e: any) => void;
+  handleBlur: (e: any) => void;
   next: () => void;
   back: () => void;
   askAI: () => void;
 }
 
-function PaymentTermsPage({ formData, handleChange, next, back, askAI }: Props) {
+function PaymentTermsPage({
+  formData,
+  handleChange,
+  handleBlur,
+  next,
+  back,
+  askAI,
+}: Props) {
   return (
     <div>
       <h2>{strings.paymentTerms}</h2>
       <div className="field-row">
         <div className="field-name">{strings.paymentTermsLabel}</div>
         <div className="field-input">
-          <input name="paymentTerms" value={formData.paymentTerms || ''} onChange={handleChange} />
+          <input
+            name="paymentTerms"
+            value={formData.paymentTerms || ''}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
           <span className="icon" role="button" title="Use recommended value">⭐</span>
           <span className="icon" role="button" title="Ask AI" onClick={askAI}>🤖</span>
         </div>

--- a/src/pages/PostingGroupsPage.tsx
+++ b/src/pages/PostingGroupsPage.tsx
@@ -3,19 +3,32 @@ import strings from '../../res/strings';
 interface Props {
   formData: { [key: string]: any };
   handleChange: (e: any) => void;
+  handleBlur: (e: any) => void;
   next: () => void;
   back: () => void;
   askAI: () => void;
 }
 
-function PostingGroupsPage({ formData, handleChange, next, back, askAI }: Props) {
+function PostingGroupsPage({
+  formData,
+  handleChange,
+  handleBlur,
+  next,
+  back,
+  askAI,
+}: Props) {
   return (
     <div>
       <h2>{strings.postingGroups}</h2>
       <div className="field-row">
         <div className="field-name">{strings.generalPostingGroupLabel}</div>
         <div className="field-input">
-          <input name="postingGroup" value={formData.postingGroup || ''} onChange={handleChange} />
+          <input
+            name="postingGroup"
+            value={formData.postingGroup || ''}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
           <span className="icon" role="button" title="Use recommended value">⭐</span>
           <span className="icon" role="button" title="Ask AI" onClick={askAI}>🤖</span>
         </div>


### PR DESCRIPTION
## Summary
- add `basicInfo` label for menu
- update config menu to include Basic Information
- add validation to form inputs
- prefill company info fields from Basic Info
- restructure step flow so home goes to menu first

## Testing
- `npm test`
- `npx vite build` *(fails: Cannot find module /vite/dist/node/cli.js)*

------
https://chatgpt.com/codex/tasks/task_e_6877939158788322b94770a90fa1fb60