### PR TITLE
Add enhanced AI suggest dialog

### DIFF
--- a/src/pages/PaymentTermsPage.tsx
+++ b/src/pages/PaymentTermsPage.tsx
@@ -6,7 +6,7 @@ interface Props {
   handleBlur: (e: any) => void;
   next: () => void;
   back: () => void;
-  askAI: () => void;
+  askAI: (field: string, key: string, cons?: string) => void;
 }
 
 function PaymentTermsPage({
@@ -30,7 +30,14 @@ function PaymentTermsPage({
             onBlur={handleBlur}
           />
           <span className="icon" role="button" title="Use recommended value">⭐</span>
-          <span className="icon" role="button" title="Ask AI" onClick={askAI}>🤖</span>
+          <span
+            className="icon"
+            role="button"
+            title="Ask AI"
+            onClick={() => askAI(strings.paymentTermsLabel, 'paymentTerms')}
+          >
+            🤖
+          </span>
         </div>
         <div className="field-considerations"></div>
       </div>

--- a/src/pages/PostingGroupsPage.tsx
+++ b/src/pages/PostingGroupsPage.tsx
@@ -6,7 +6,7 @@ interface Props {
   handleBlur: (e: any) => void;
   next: () => void;
   back: () => void;
-  askAI: () => void;
+  askAI: (field: string, key: string, cons?: string) => void;
 }
 
 function PostingGroupsPage({
@@ -30,7 +30,14 @@ function PostingGroupsPage({
             onBlur={handleBlur}
           />
           <span className="icon" role="button" title="Use recommended value">⭐</span>
-          <span className="icon" role="button" title="Ask AI" onClick={askAI}>🤖</span>
+          <span
+            className="icon"
+            role="button"
+            title="Ask AI"
+            onClick={() => askAI(strings.generalPostingGroupLabel, 'postingGroup')}
+          >
+            🤖
+          </span>
         </div>
         <div className="field-considerations"></div>
       </div>


### PR DESCRIPTION
## Summary
- enhance AI suggest feature to fetch a recommended value from OpenAI when a user clicks the AI icon
- include extra instruction textbox and ability to requery
- allow accepting the returned value to fill the field

## Testing
- `npm test`
- `npm run build` *(fails: `vite: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_687796524e1083229e65fcc0a0a96cb5