### PR TITLE
Use field mappings to seed defaults

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,9 +14,9 @@ import GLSetupPage from './pages/GLSetupPage';
 import SalesReceivablesPage from './pages/SalesReceivablesPage';
 import strings from '../res/strings';
 import { CompanyField, BasicInfo } from './types';
-import { fieldKey } from './utils/helpers';
+import { fieldKey, findFieldValue, mapFieldName } from './utils/helpers';
 import { parseCompanyInfo, parseGuideTable, recommendedCode } from './utils/jsonParsing';
-import { loadStartingData, loadConfigTables } from './utils/dataLoader';
+import { loadStartingData, loadConfigTables, loadFieldMappings } from './utils/dataLoader';
 
 const glFieldNames = [
   'Allow Posting From / Allow Posting To',
@@ -100,6 +100,8 @@ function App() {
   const [countries, setCountries] = useState([] as { code: string; name: string }[]);
   const [currencies, setCurrencies] = useState([] as { code: string; description: string }[]);
   const [paymentTermsOptions, setPaymentTermsOptions] = useState([] as { code: string; description: string }[]);
+  const [startData, setStartData] = useState<any>(null);
+  const [fieldMappings, setFieldMappings] = useState<Record<string, string>>({});
   const [showAI, setShowAI] = useState(false);
   const [aiSuggested, setAiSuggested] = useState('');
   const [aiExtra, setAiExtra] = useState('');
@@ -126,6 +128,10 @@ function App() {
         const data = await loadStartingData();
         logDebug('Starting data loaded');
         setRapidStart(JSON.stringify(data));
+        setStartData(data);
+        logDebug('Loading field mappings');
+        const mappings = await loadFieldMappings();
+        setFieldMappings(mappings);
 
         const countries =
           data?.DataList?.CountryRegionList?.CountryRegion?.map((c: any) => ({
@@ -166,6 +172,25 @@ function App() {
     }
     init();
   }, []);
+
+  useEffect(() => {
+    if (!startData || Object.keys(fieldMappings).length === 0) return;
+    const all = [...companyFields, ...glFields, ...srFields];
+    setFormData(f => {
+      const copy: FormData = { ...f };
+      all.forEach(cf => {
+        const key = fieldKey(cf.field);
+        if (copy[key]) return;
+        const internal = mapFieldName(cf.field, fieldMappings);
+        if (!internal) return;
+        const val = findFieldValue(startData, internal);
+        if (val !== undefined) {
+          copy[key] = val;
+        }
+      });
+      return copy;
+    });
+  }, [startData, fieldMappings, companyFields, glFields, srFields]);
 
   useEffect(() => {
     const nameKey = fieldKey('Company Name');

--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -20,3 +20,8 @@ export async function loadConfigTables(): Promise<any> {
   const resp = await fetch('/config_tables.json');
   return await resp.json();
 }
+
+export async function loadFieldMappings(): Promise<Record<string, string>> {
+  const resp = await fetch('/field_name_mappings.json');
+  return await resp.json();
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,3 +1,43 @@
 export function fieldKey(name: string): string {
   return name.replace(/[^a-zA-Z0-9]/g, '_');
 }
+
+export function mapFieldName(
+  name: string,
+  mappings: Record<string, string>
+): string | undefined {
+  if (mappings[name]) return mappings[name];
+  const norm = name.replace(/\s+/g, ' ').trim().toLowerCase();
+  for (const key of Object.keys(mappings)) {
+    const kNorm = key.replace(/\s+/g, ' ').trim().toLowerCase();
+    if (kNorm === norm) return mappings[key];
+  }
+  return undefined;
+}
+
+export function findFieldValue(obj: any, field: string): any {
+  if (!obj || typeof obj !== 'object') return undefined;
+  if (Object.prototype.hasOwnProperty.call(obj, field)) {
+    const val = obj[field];
+    if (Array.isArray(val)) {
+      for (const v of val) {
+        const found = findFieldValue(v, '#text');
+        if (found !== undefined) return found;
+      }
+    } else if (typeof val === 'object') {
+      if ('#text' in val) return val['#text'];
+      const found = findFieldValue(val, '#text');
+      if (found !== undefined) return found;
+    } else {
+      return val;
+    }
+  }
+  for (const key of Object.keys(obj)) {
+    const child = obj[key];
+    if (typeof child === 'object') {
+      const found = findFieldValue(child, field);
+      if (found !== undefined) return found;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- load `field_name_mappings.json` alongside the RapidStart XML
- expose helper utilities to map field names and retrieve values from the parsed XML
- when config tables load, apply defaults from the RapidStart data using the mappings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c51ea37c8322ae643ef160ae4cd6