### PR TITLE
Fix LCY code input

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -425,16 +425,7 @@ function App() {
         </select>
       );
     } else if (cf.field === 'Local Currency (LCY) Code') {
-      inputEl = (
-        <select name={key} value={val} onChange={handleChange}>
-          <option value=""></option>
-          {currencies.map(c => (
-            <option key={c.code} value={c.code}>
-              {c.code}
-            </option>
-          ))}
-        </select>
-      );
+      inputEl = <input {...inputProps} />;
     }
     const acceptRecommended = () => {
       setFormData((f: FormData) => ({


### PR DESCRIPTION
## Summary
- use a text input for **Local Currency (LCY) Code** instead of a dropdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c70e5fec8322907765496eddc7eb