### PR TITLE
Add editable dropdowns

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -100,6 +100,7 @@ function App() {
   const [countries, setCountries] = useState([] as { code: string; name: string }[]);
   const [currencies, setCurrencies] = useState([] as { code: string; description: string }[]);
   const [paymentTermsOptions, setPaymentTermsOptions] = useState([] as { code: string; description: string }[]);
+  const [baseCalendarOptions, setBaseCalendarOptions] = useState(['STANDARD']);
   const [showAI, setShowAI] = useState(false);
   const [aiSuggested, setAiSuggested] = useState('');
   const [aiExtra, setAiExtra] = useState('');
@@ -241,6 +242,24 @@ function App() {
   function handleBlur(e: any): void {
     if (!e.target.checkValidity()) {
       alert('Invalid value');
+    }
+    const { name, value } = e.target;
+    if (name === 'paymentTerms') {
+      if (value && !paymentTermsOptions.find(o => o.code === value)) {
+        setPaymentTermsOptions([...paymentTermsOptions, { code: value, description: value }]);
+      }
+    } else if (name === fieldKey('Base Calendar Code')) {
+      if (value && !baseCalendarOptions.includes(value)) {
+        setBaseCalendarOptions([...baseCalendarOptions, value]);
+      }
+    } else if (name === fieldKey('Country/Region Code')) {
+      if (value && !countries.find(c => c.code === value)) {
+        setCountries([...countries, { code: value, name: value }]);
+      }
+    } else if (name === fieldKey('Local Currency (LCY) Code')) {
+      if (value && !currencies.find(c => c.code === value)) {
+        setCurrencies([...currencies, { code: value, description: value }]);
+      }
     }
   }
 
@@ -403,37 +422,60 @@ function App() {
     if (cf.field === 'Logo (Picture)') {
       inputEl = <input type="file" name={key} onChange={handleChange} />;
     } else if (cf.field === 'Base Calendar Code') {
-      const options = ['', 'STANDARD'];
       inputEl = (
-        <select name={key} value={val} onChange={handleChange}>
-          {options.map(o => (
-            <option key={o} value={o}>
-              {o}
-            </option>
-          ))}
-        </select>
+        <>
+          <input
+            list="base-calendar-list"
+            name={key}
+            value={val}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+          <datalist id="base-calendar-list">
+            <option value="" />
+            {baseCalendarOptions.map(o => (
+              <option key={o} value={o} />
+            ))}
+          </datalist>
+        </>
       );
     } else if (cf.field === 'Country/Region Code') {
       inputEl = (
-        <select name={key} value={val} onChange={handleChange}>
-          <option value=""></option>
-          {countries.map((c: { code: string; name: string }) => (
-            <option key={c.code} value={c.code}>
-              {c.name || c.code}
-            </option>
-          ))}
-        </select>
+        <>
+          <input
+            list="country-list"
+            name={key}
+            value={val}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+          <datalist id="country-list">
+            <option value="" />
+            {countries.map((c: { code: string; name: string }) => (
+              <option key={c.code} value={c.code}>
+                {c.name || c.code}
+              </option>
+            ))}
+          </datalist>
+        </>
       );
     } else if (cf.field === 'Local Currency (LCY) Code') {
       inputEl = (
-        <select name={key} value={val} onChange={handleChange}>
-          <option value=""></option>
-          {currencies.map(c => (
-            <option key={c.code} value={c.code}>
-              {c.code}
-            </option>
-          ))}
-        </select>
+        <>
+          <input
+            list="currency-list"
+            name={key}
+            value={val}
+            onChange={handleChange}
+            onBlur={handleBlur}
+          />
+          <datalist id="currency-list">
+            <option value="" />
+            {currencies.map(c => (
+              <option key={c.code} value={c.code} />
+            ))}
+          </datalist>
+        </>
       );
     }
     const acceptRecommended = () => {

--- a/src/pages/BasicInfoPage.tsx
+++ b/src/pages/BasicInfoPage.tsx
@@ -1,5 +1,6 @@
 import strings from '../../res/strings';
 import { BasicInfo } from '../types';
+import React, { useState } from 'react';
 
 interface Props {
   formData: BasicInfo;
@@ -9,7 +10,7 @@ interface Props {
   back: () => void;
 }
 
-const industries = [
+const initialIndustries = [
   'Manufacturing',
   'Retail',
   'Healthcare',
@@ -29,6 +30,15 @@ function BasicInfoPage({
   next,
   back,
 }: Props) {
+  const [industries, setIndustries] = useState(initialIndustries);
+
+  function handleIndustryBlur(e: any) {
+    handleBlur(e);
+    const val = e.target.value.trim();
+    if (val && !industries.includes(val)) {
+      setIndustries([...industries, val]);
+    }
+  }
   return (
     <div>
       <h2>{strings.basicInfoTitle}</h2>
@@ -52,7 +62,7 @@ function BasicInfoPage({
             name="industry"
             value={data.industry || ''}
             onChange={handleChange}
-            onBlur={handleBlur}
+            onBlur={handleIndustryBlur}
           />
           <datalist id="industry-list">
             {industries.map(ind => (

--- a/src/pages/PaymentTermsPage.tsx
+++ b/src/pages/PaymentTermsPage.tsx
@@ -25,18 +25,20 @@ function PaymentTermsPage({
       <div className="field-row">
         <div className="field-name">{strings.paymentTermsLabel}</div>
         <div className="field-input">
-          <select
+          <input
+            list="payment-terms-list"
             name="paymentTerms"
             value={formData.paymentTerms || ''}
             onChange={handleChange}
             onBlur={handleBlur}
-          >
+          />
+          <datalist id="payment-terms-list">
             {options.map(o => (
               <option key={o.code} value={o.code}>
                 {o.description || o.code}
               </option>
             ))}
-          </select>
+          </datalist>
           <span className="icon" role="button" title="Use recommended value">⭐</span>
           <span
             className="icon"


### PR DESCRIPTION
## Summary
- allow typing new industry and keep it in the list
- switch payment terms dropdown to an editable list
- track additional Base Calendar, Country, and Currency codes
- persist custom values when fields blur

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c666fa9c83228485da3dd84f8d3a