### PR TITLE
Use new lookup config and dynamic dropdowns

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -14,7 +14,13 @@ import GLSetupPage from './pages/GLSetupPage';
 import SalesReceivablesPage from './pages/SalesReceivablesPage';
 import strings from '../res/strings';
 import { CompanyField, BasicInfo } from './types';
-import { fieldKey, findFieldValue, mapFieldName } from './utils/helpers';
+import {
+  fieldKey,
+  findFieldValue,
+  mapFieldName,
+  findTableRows,
+  extractFieldValues,
+} from './utils/helpers';
 import { parseQuestions, recommendedCode } from './utils/jsonParsing';
 import { loadStartingData, loadConfigTables } from './utils/dataLoader';
 
@@ -539,6 +545,19 @@ function App() {
       );
     } else if (cf.field === 'Local Currency (LCY) Code') {
       inputEl = <input {...inputProps} />;
+    } else if (cf.lookupTable && startData) {
+      const rows = findTableRows(startData, cf.lookupTable) || [];
+      const opts = extractFieldValues(rows, cf.lookupField || 'Code');
+      inputEl = (
+        <select {...inputProps}>
+          <option value="" />
+          {opts.map(o => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      );
     }
     const acceptRecommended = () => {
       setFormData((f: FormData) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ export interface CompanyField {
   recommended: string;
   considerations: string;
   common: 'common' | 'sometimes' | 'unlikely';
+  lookupTable?: number;
+  lookupField?: string;
 }
 
 export interface BasicInfo {

--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -17,7 +17,7 @@ export async function loadStartingData(): Promise<any> {
 }
 
 export async function loadConfigTables(): Promise<any> {
-  const resp = await fetch('/config_table_questions_common.json');
+  const resp = await fetch('/config_table_questions_common_with_lookup.json');
   return await resp.json();
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -32,3 +32,49 @@ export function findFieldValue(obj: any, field: string): any {
   }
   return undefined;
 }
+
+export function findTableRows(obj: any, tableId: number): any[] | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const idObj = (obj as any)['TableID'];
+  let idVal: any = undefined;
+  if (idObj !== undefined) {
+    if (typeof idObj === 'object' && '#text' in idObj) idVal = idObj['#text'];
+    else idVal = idObj;
+  }
+  if (idVal !== undefined && Number(idVal) === tableId) {
+    for (const key of Object.keys(obj)) {
+      if (key === 'TableID' || key === 'PageID' || key === '#text' || key.startsWith('@')) continue;
+      const rows: any = (obj as any)[key];
+      if (Array.isArray(rows)) return rows;
+      if (rows && typeof rows === 'object') return [rows];
+    }
+  }
+  for (const key of Object.keys(obj)) {
+    const child = (obj as any)[key];
+    if (Array.isArray(child)) {
+      for (const c of child) {
+        const found = findTableRows(c, tableId);
+        if (found) return found;
+      }
+    } else if (typeof child === 'object') {
+      const found = findTableRows(child, tableId);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+export function extractFieldValues(rows: any[], field: string): string[] {
+  const vals: string[] = [];
+  rows.forEach(r => {
+    let v: any = r ? r[field] : undefined;
+    if (v !== undefined && v !== null) {
+      if (typeof v === 'object' && '#text' in v) v = v['#text'];
+      if (v !== undefined && v !== null) {
+        const s = String(v);
+        if (s && !vals.includes(s)) vals.push(s);
+      }
+    }
+  });
+  return vals;
+}

--- a/src/utils/jsonParsing.ts
+++ b/src/utils/jsonParsing.ts
@@ -5,6 +5,8 @@ export interface ConfigQuestion {
   RecommendedSetting?: string;
   Considerations?: string;
   common?: string;
+  'Lookup Table'?: number;
+  'Lookup Field'?: string;
 }
 
 export function recommendedCode(text: string): string {
@@ -32,6 +34,12 @@ export function parseQuestions(
       recommended: q?.RecommendedSetting || '',
       considerations: q?.Considerations || '',
       common,
+      lookupTable: (q as any)?.['Lookup Table']
+        ? Number((q as any)['Lookup Table'])
+        : undefined,
+      lookupField: (q as any)?.['Lookup Field']
+        ? String((q as any)['Lookup Field'])
+        : undefined,
     };
   });
 }


### PR DESCRIPTION
## Summary
- load `config_table_questions_common_with_lookup.json`
- add lookup table info to `CompanyField`
- support dropdowns from lookup tables
- add helper utilities for table lookups

## Testing
- `npm test`
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6878207a1e748322bd1bacbb7511294a