### PR TITLE
Update next button styles

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -36,4 +36,5 @@ export default {
   fileCreated: 'File created:',
   debugLog: 'Debug Log',
   home: 'Home',
+  skip: 'Skip',
 };

--- a/src/pages/BasicInfoPage.tsx
+++ b/src/pages/BasicInfoPage.tsx
@@ -100,7 +100,8 @@ function BasicInfoPage({
       </div>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -37,7 +37,8 @@ function CompanyInfoPage({
       </details>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -12,7 +12,8 @@ function CustomersPage({ next, back }: Props) {
       <p>Coming soon.</p>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -28,7 +28,8 @@ function GLSetupPage({ fields, formData, handleChange, renderField, next, back }
       </details>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/ItemsPage.tsx
+++ b/src/pages/ItemsPage.tsx
@@ -12,7 +12,8 @@ function ItemsPage({ next, back }: Props) {
       <p>Coming soon.</p>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/PaymentTermsPage.tsx
+++ b/src/pages/PaymentTermsPage.tsx
@@ -53,7 +53,8 @@ function PaymentTermsPage({
       </div>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/PostingGroupsPage.tsx
+++ b/src/pages/PostingGroupsPage.tsx
@@ -43,7 +43,8 @@ function PostingGroupsPage({
       </div>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -35,7 +35,8 @@ function SalesReceivablesPage({
       </details>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/src/pages/VendorsPage.tsx
+++ b/src/pages/VendorsPage.tsx
@@ -12,7 +12,8 @@ function VendorsPage({ next, back }: Props) {
       <p>Coming soon.</p>
       <div className="nav">
         <button onClick={back}>{strings.back}</button>
-        <button onClick={next}>{strings.next}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-link" onClick={next}>{strings.skip}</button>
       </div>
     </div>
   );

--- a/style.css
+++ b/style.css
@@ -340,3 +340,33 @@ h3 {
   background: #0078d4;
   width: 0;
 }
+
+/* Big next button and skip link */
+.next-btn {
+  background-color: #008080;
+  color: #fff;
+  border: 1px solid #006b6b;
+  border-radius: 6px;
+  padding: 12px 24px;
+  font-size: 1.1em;
+  cursor: pointer;
+  margin-right: 10px;
+}
+
+.next-btn:hover {
+  background-color: #006b6b;
+}
+
+.skip-link {
+  background: none;
+  border: none;
+  color: #0078d4;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: 1em;
+  padding: 0;
+}
+
+.skip-link:hover {
+  text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- add `skip` string for new nav UI
- support larger primary button with accompanying skip link
- update question pages to use `.next-btn` and `.skip-link` styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ae0ec5cc8322811ca97e875286dc