### PR TITLE
Restore PNG logo and tidy nav

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Node.js Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with Vite
+        run: npx vite build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Node.js CI
+name: Node.js Test
 
 on:
   push:
@@ -7,26 +7,18 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [18.x]
-
     steps:
       - uses: actions/checkout@v4
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
       - name: Install dependencies
         run: npm ci
-
-      - name: Build with Vite
-        run: npx vite build
-
       - name: Run tests
         run: npm test

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,7 +15,7 @@ import SalesReceivablesPage from './pages/SalesReceivablesPage';
 import CustomersPage from './pages/CustomersPage';
 import VendorsPage from './pages/VendorsPage';
 import ItemsPage from './pages/ItemsPage';
-import BCLogo from './images/Examples/BClogo.svg';
+import BCLogo from './images/Examples/BC Logo.png';
 import strings from '../res/strings';
 import { CompanyField, BasicInfo } from './types';
 import {

--- a/src/images/Examples/BClogo.svg
+++ b/src/images/Examples/BClogo.svg
@@ -1,8 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
-  <circle cx="50" cy="50" r="45" fill="#0078d4" />
-  <circle cx="50" cy="50" r="12" fill="#ffffff" />
-  <circle cx="50" cy="20" r="10" fill="#ffffff" />
-  <circle cx="50" cy="80" r="10" fill="#ffffff" />
-  <circle cx="20" cy="50" r="10" fill="#ffffff" />
-  <circle cx="80" cy="50" r="10" fill="#ffffff" />
-</svg>

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -80,9 +80,6 @@ function ConfigMenuPage({
           </div>
         </div>
       </div>
-      <div className="nav">
-        <button className="next-btn" onClick={back}>{strings.back}</button>
-      </div>
     </div>
   );
 }

--- a/style.css
+++ b/style.css
@@ -267,11 +267,15 @@ h3 {
   align-items: center;
   gap: 4px;
   margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #d0d0d0;
 }
 
 .sidebar-header h2 {
   font-size: 1.1em;
   white-space: nowrap;
+  align-self: flex-start;
+  margin-left: 15px;
 }
 
 .sidebar-header .logo {


### PR DESCRIPTION
## Summary
- revert to PNG BC logo
- remove Back button from navigation homepage
- tidy sidebar header with divider and left aligned heading
- split workflows into build and test for faster parallel runs

## Testing
- `npm test`
- `npx vite build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6878b9b950708322b715252c45d56bda