### PR TITLE
Implement per-field wizard UI

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -37,4 +37,5 @@ export default {
   debugLog: 'Debug Log',
   home: 'Home',
   skip: 'Skip',
+  allCommonComplete: 'All common fields completed',
 };

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -482,7 +482,7 @@ function App() {
     }
   }
 
-  function renderField(cf: CompanyField) {
+  function renderInput(cf: CompanyField) {
     const key = fieldKey(cf.field);
     const val = formData[key] || '';
     let inputProps: any = {
@@ -491,10 +491,19 @@ function App() {
       onChange: handleChange,
       onBlur: handleBlur,
     };
+    if (cf.fieldType === 'Boolean') {
+      return (
+        <>
+          <label><input type="radio" name={key} value="1" checked={val === '1'} onChange={handleChange}/> Yes</label>
+          <label><input type="radio" name={key} value="0" checked={val === '0'} onChange={handleChange}/> No</label>
+          <label><input type="radio" name={key} value="" checked={val === ''} onChange={handleChange}/> I'm not sure</label>
+        </>
+      );
+    }
     if (/phone/i.test(cf.field)) {
       inputProps.type = 'tel';
       inputProps.pattern = '[0-9+()\- ]+';
-    } else if (/date/i.test(cf.field)) {
+    } else if (cf.fieldType === 'Date' || /date/i.test(cf.field)) {
       inputProps.type = 'date';
     } else if (/number|amount|qty|quantity/i.test(cf.field)) {
       inputProps.type = 'number';
@@ -582,34 +591,40 @@ function App() {
     };
 
     return (
-      <div className="field-row" key={key}>
-        <div className="field-name">{cf.field}</div>
-        <div className="field-input">
-          {inputEl}
-          {cf.recommended && (
-            <span
-              className="icon"
-              role="button"
-              title="Use recommended value"
-              onClick={handleRecommended}
-            >
-              ⭐
-            </span>
-          )}
+      <>
+        {inputEl}
+        {cf.recommended && (
           <span
             className="icon"
             role="button"
-            title="Ask AI"
-            onClick={() => openAIDialog(cf.field, key, cf.considerations)}
+            title="Use recommended value"
+            onClick={handleRecommended}
           >
-            🤖
+            ⭐
           </span>
-        </div>
+        )}
+        <span
+          className="icon"
+          role="button"
+          title="Ask AI"
+          onClick={() => openAIDialog(cf.field, key, cf.considerations)}
+        >
+          🤖
+        </span>
+      </>
+    );
+  }
+
+  function renderField(cf: CompanyField) {
+    const key = fieldKey(cf.field);
+    return (
+      <div className="field-row" key={key}>
+        <div className="field-name">{cf.field}</div>
+        <div className="field-input">{renderInput(cf)}</div>
         <div className="field-considerations">{cf.considerations}</div>
       </div>
     );
   }
-
   const currentGroup = (() => {
     if (step === 2) return 'basic';
     if ([3, 4, 5, 6, 7].includes(step)) return 'config';
@@ -732,9 +747,7 @@ function App() {
       {step === 3 && (
         <CompanyInfoPage
           fields={companyFields}
-          formData={formData}
-          handleChange={handleChange}
-          renderField={renderField}
+          renderInput={renderInput}
           next={next}
           back={() => setStep(1)}
         />
@@ -763,9 +776,7 @@ function App() {
       {step === 6 && (
         <GLSetupPage
           fields={glFields}
-          formData={formData}
-          handleChange={handleChange}
-          renderField={renderField}
+          renderInput={renderInput}
           next={next}
           back={back}
         />
@@ -773,13 +784,11 @@ function App() {
       {step === 7 && (
         <SalesReceivablesPage
           fields={srFields}
-          formData={formData}
-          handleChange={handleChange}
-          renderField={renderField}
+          renderInput={renderInput}
           next={next}
           back={back}
         />
-          )}
+      )}
           {step === 8 && <CustomersPage next={next} back={back} />}
           {step === 9 && <VendorsPage next={next} back={back} />}
           {step === 10 && <ItemsPage next={next} back={back} />}

--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { CompanyField } from '../types';
+
+interface Props {
+  field: CompanyField;
+  renderInput: (cf: CompanyField) => React.ReactNode;
+  onConfirm: () => void;
+  onSkip: () => void;
+}
+
+function FieldSubPage({ field: cf, renderInput, onConfirm, onSkip }: Props) {
+  return (
+    <div className="subpage-field">
+      <div className="subpage-left">
+        <div className="question"><strong>{cf.question}</strong></div>
+        <div className="field-ref">{cf.field}</div>
+        {cf.recommended && (
+          <div className="recommended">Recommended: {cf.recommended}</div>
+        )}
+        <div className="input-area">{renderInput(cf)}</div>
+      </div>
+      <div className="subpage-considerations">{cf.considerations}</div>
+      <div className="nav">
+        <button className="next-btn" onClick={onConfirm}>Confirm</button>
+        <button className="skip-btn" onClick={onSkip}>Skip</button>
+      </div>
+    </div>
+  );
+}
+
+export default FieldSubPage;

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import { CompanyField } from '../types';
+import FieldSubPage from './FieldSubPage';
+import strings from '../../res/strings';
+
+interface Props {
+  title: string;
+  fields: CompanyField[];
+  renderInput: (cf: CompanyField) => React.ReactNode;
+  next: () => void;
+  back: () => void;
+}
+
+function FieldWizard({ title, fields, renderInput, next, back }: Props) {
+  const common = fields.filter(f => f.common === 'common');
+  const sometimes = fields.filter(f => f.common === 'sometimes');
+  const unlikely = fields.filter(f => f.common === 'unlikely');
+
+  const [cIdx, setCIdx] = useState(0);
+  const [cDone, setCDone] = useState<boolean[]>(common.map(() => false));
+  const [sIdx, setSIdx] = useState(0);
+  const [uIdx, setUIdx] = useState(0);
+  const [showSometimes, setShowSometimes] = useState(false);
+  const [showUnlikely, setShowUnlikely] = useState(false);
+
+  const progress = common.length
+    ? Math.round((cDone.filter(Boolean).length / common.length) * 100)
+    : 100;
+
+  function confirmCommon() {
+    const arr = [...cDone];
+    arr[cIdx] = true;
+    setCDone(arr);
+    nextCommon();
+  }
+  function skipCommon() {
+    nextCommon();
+  }
+  function nextCommon() {
+    if (cIdx + 1 < common.length) setCIdx(cIdx + 1);
+  }
+
+  function confirmSome() {
+    nextSome();
+  }
+  function skipSome() {
+    nextSome();
+  }
+  function nextSome() {
+    if (sIdx + 1 < sometimes.length) setSIdx(sIdx + 1);
+    else setShowSometimes(false);
+  }
+
+  function confirmUnlikely() {
+    nextUnlikely();
+  }
+  function skipUnlikely() {
+    nextUnlikely();
+  }
+  function nextUnlikely() {
+    if (uIdx + 1 < unlikely.length) setUIdx(uIdx + 1);
+    else setShowUnlikely(false);
+  }
+
+  return (
+    <div>
+      <h2>{title}</h2>
+      {common[cIdx] && (
+        <FieldSubPage
+          field={common[cIdx]}
+          renderInput={renderInput}
+          onConfirm={confirmCommon}
+          onSkip={skipCommon}
+        />
+      )}
+      {!common[cIdx] && <div>{strings.allCommonComplete}</div>}
+
+      <details open={showSometimes} onToggle={e => setShowSometimes(e.currentTarget.open)}>
+        <summary>{strings.sometimes}</summary>
+        {showSometimes && sometimes[sIdx] && (
+          <FieldSubPage
+            field={sometimes[sIdx]}
+            renderInput={renderInput}
+            onConfirm={confirmSome}
+            onSkip={skipSome}
+          />
+        )}
+      </details>
+
+      <details open={showUnlikely} onToggle={e => setShowUnlikely(e.currentTarget.open)}>
+        <summary>{strings.additional}</summary>
+        {showUnlikely && unlikely[uIdx] && (
+          <FieldSubPage
+            field={unlikely[uIdx]}
+            renderInput={renderInput}
+            onConfirm={confirmUnlikely}
+            onSkip={skipUnlikely}
+          />
+        )}
+      </details>
+
+      <div className="status-bar">
+        <div className="status-fill" style={{ width: `${progress}%` }} />
+      </div>
+
+      <div className="nav">
+        <button className="next-btn" onClick={back}>{strings.back}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+      </div>
+    </div>
+  );
+}
+
+export default FieldWizard;

--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -1,5 +1,6 @@
 import { CompanyField } from '../types';
 import strings from '../../res/strings';
+import FieldWizard from '../components/FieldWizard';
 
 interface FormData {
   [key: string]: any;
@@ -7,40 +8,20 @@ interface FormData {
 
 interface Props {
   fields: CompanyField[];
-  formData: FormData;
-  handleChange: (e: any) => void;
-  renderField: (cf: CompanyField) => any;
+  renderInput: (cf: CompanyField) => any;
   next: () => void;
   back: () => void;
 }
 
-function CompanyInfoPage({
-  fields,
-  formData,
-  handleChange,
-  renderField,
-  next,
-  back,
-}: Props) {
+function CompanyInfoPage({ fields, renderInput, next, back }: Props) {
   return (
-    <div>
-      <h2>{strings.companyInfo}</h2>
-      <h3>{strings.common}</h3>
-      {fields.filter(cf => cf.common === 'common').map(renderField)}
-      <details>
-        <summary>{strings.sometimes}</summary>
-        {fields.filter(cf => cf.common === 'sometimes').map(renderField)}
-      </details>
-      <details>
-        <summary>{strings.additional}</summary>
-        {fields.filter(cf => cf.common === 'unlikely').map(renderField)}
-      </details>
-      <div className="nav">
-        <button className="next-btn" onClick={back}>{strings.back}</button>
-        <button className="next-btn" onClick={next}>{strings.next}</button>
-        <button className="skip-btn" onClick={next}>{strings.skip}</button>
-      </div>
-    </div>
+    <FieldWizard
+      title={strings.companyInfo}
+      fields={fields}
+      renderInput={renderInput}
+      next={next}
+      back={back}
+    />
   );
 }
 

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -1,37 +1,25 @@
 import { CompanyField } from '../types';
 import strings from '../../res/strings';
+import FieldWizard from '../components/FieldWizard';
 
 interface FormData { [key: string]: any }
 
 interface Props {
   fields: CompanyField[];
-  formData: FormData;
-  handleChange: (e: any) => void;
-  renderField: (cf: CompanyField) => any;
+  renderInput: (cf: CompanyField) => any;
   next: () => void;
   back: () => void;
 }
 
-function GLSetupPage({ fields, formData, handleChange, renderField, next, back }: Props) {
+function GLSetupPage({ fields, renderInput, next, back }: Props) {
   return (
-    <div>
-      <h2>{strings.generalLedgerSetup}</h2>
-      <h3>{strings.common}</h3>
-      {fields.filter(cf => cf.common === 'common').map(renderField)}
-      <details>
-        <summary>{strings.sometimes}</summary>
-        {fields.filter(cf => cf.common === 'sometimes').map(renderField)}
-      </details>
-      <details>
-        <summary>{strings.additional}</summary>
-        {fields.filter(cf => cf.common === 'unlikely').map(renderField)}
-      </details>
-      <div className="nav">
-        <button className="next-btn" onClick={back}>{strings.back}</button>
-        <button className="next-btn" onClick={next}>{strings.next}</button>
-        <button className="skip-btn" onClick={next}>{strings.skip}</button>
-      </div>
-    </div>
+    <FieldWizard
+      title={strings.generalLedgerSetup}
+      fields={fields}
+      renderInput={renderInput}
+      next={next}
+      back={back}
+    />
   );
 }
 

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -1,44 +1,25 @@
 import { CompanyField } from '../types';
 import strings from '../../res/strings';
+import FieldWizard from '../components/FieldWizard';
 
 interface FormData { [key: string]: any }
 
 interface Props {
   fields: CompanyField[];
-  formData: FormData;
-  handleChange: (e: any) => void;
-  renderField: (cf: CompanyField) => any;
+  renderInput: (cf: CompanyField) => any;
   next: () => void;
   back: () => void;
 }
 
-function SalesReceivablesPage({
-  fields,
-  formData,
-  handleChange,
-  renderField,
-  next,
-  back,
-}: Props) {
+function SalesReceivablesPage({ fields, renderInput, next, back }: Props) {
   return (
-    <div>
-      <h2>{strings.salesReceivablesSetup}</h2>
-      <h3>{strings.common}</h3>
-      {fields.filter(cf => cf.common === 'common').map(renderField)}
-      <details>
-        <summary>{strings.sometimes}</summary>
-        {fields.filter(cf => cf.common === 'sometimes').map(renderField)}
-      </details>
-      <details>
-        <summary>{strings.additional}</summary>
-        {fields.filter(cf => cf.common === 'unlikely').map(renderField)}
-      </details>
-      <div className="nav">
-        <button className="next-btn" onClick={back}>{strings.back}</button>
-        <button className="next-btn" onClick={next}>{strings.next}</button>
-        <button className="skip-btn" onClick={next}>{strings.skip}</button>
-      </div>
-    </div>
+    <FieldWizard
+      title={strings.salesReceivablesSetup}
+      fields={fields}
+      renderInput={renderInput}
+      next={next}
+      back={back}
+    />
   );
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,8 @@ export interface CompanyField {
   recommended: string;
   considerations: string;
   common: 'common' | 'sometimes' | 'unlikely';
+  fieldType?: string;
+  question?: string;
   lookupTable?: number;
   lookupField?: string;
 }

--- a/src/utils/jsonParsing.ts
+++ b/src/utils/jsonParsing.ts
@@ -5,6 +5,8 @@ export interface ConfigQuestion {
   RecommendedSetting?: string;
   Considerations?: string;
   common?: string;
+  FieldType?: string;
+  Question?: string;
   'Lookup Table'?: number;
   'Lookup Field'?: string;
 }
@@ -34,6 +36,8 @@ export function parseQuestions(
       recommended: q?.RecommendedSetting || '',
       considerations: q?.Considerations || '',
       common,
+      fieldType: q?.FieldType,
+      question: q?.Question,
       lookupTable: (q as any)?.['Lookup Table']
         ? Number((q as any)['Lookup Table'])
         : undefined,

--- a/style.css
+++ b/style.css
@@ -404,3 +404,47 @@ h3 {
 .skip-btn:hover {
   background-color: rgba(0, 128, 128, 0.1);
 }
+
+/* Field wizard layout */
+.subpage-field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.subpage-left {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-ref {
+  font-size: 0.9em;
+  color: #666;
+}
+
+.recommended {
+  font-size: 0.9em;
+  color: #555;
+}
+
+.subpage-considerations {
+  margin-top: 10px;
+  font-size: 0.9em;
+  color: #555;
+}
+
+.status-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #f3f2f1;
+  padding: 6px;
+}
+
+.status-fill {
+  height: 8px;
+  background: #0078d4;
+  width: 0;
+}


### PR DESCRIPTION
## Summary
- extend `CompanyField` with question and field type fields
- parse question and field type in `parseQuestions`
- add `FieldSubPage` and `FieldWizard` components
- convert Company Info, GL Setup and Sales & Receivables pages to use field wizard
- show progress bar for confirmed fields
- update strings and styling

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: cannot find modules and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6878c2fe83c083229e95418a33cd1c25