### PR TITLE
Update navigation styles and progress UI

### DIFF
--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -26,9 +26,22 @@ function FieldWizard({ title, fields, renderInput, next, back }: Props) {
   const [sDone, setSDone] = useState(false);
   const [uDone, setUDone] = useState(false);
 
-  const progress = common.length
-    ? Math.round((cDone.filter(Boolean).length / common.length) * 100)
+  const confirmedCommon = cDone.filter(Boolean).length;
+  let currentConfirmed = confirmedCommon;
+  let currentTotal = common.length;
+  let progress = currentTotal
+    ? Math.round((currentConfirmed / currentTotal) * 100)
     : 100;
+
+  if (stage === 'sometimes') {
+    currentConfirmed = sIdx;
+    currentTotal = sometimes.length;
+    progress = currentTotal ? Math.round((currentConfirmed / currentTotal) * 100) : 100;
+  } else if (stage === 'unlikely') {
+    currentConfirmed = uIdx;
+    currentTotal = unlikely.length;
+    progress = currentTotal ? Math.round((currentConfirmed / currentTotal) * 100) : 100;
+  }
 
   function confirmCommon() {
     const arr = [...cDone];
@@ -175,9 +188,14 @@ function FieldWizard({ title, fields, renderInput, next, back }: Props) {
       )}
 
       {(stage === 'common' || stage === 'sometimes' || stage === 'unlikely') && (
-        <div className="status-bar">
-          <div className="status-fill" style={{ width: `${progress}%` }} />
-        </div>
+        <>
+          <div className="status-bar">
+            <div className="status-fill" style={{ width: `${progress}%` }} />
+          </div>
+          <div className="status-text">
+            Completed {currentConfirmed} of {currentTotal} tasks
+          </div>
+        </>
       )}
     </div>
   );

--- a/style.css
+++ b/style.css
@@ -276,7 +276,7 @@ h3 {
   background: #fff;
   padding: 10px;
   border-right: 1px solid #d0d0d0;
-  border-radius: 0 16px 16px 0;
+  border-radius: 0;
   box-shadow: 2px 0 4px rgba(0, 0, 0, 0.05);
 }
 
@@ -336,7 +336,7 @@ h3 {
 .sidebar li {
   margin: 4px 0;
   cursor: pointer;
-  color: var(--bc-blue);
+  color: #333;
   padding: 2px 4px;
   border-radius: 8px;
   transition: background-color 0.2s;
@@ -487,7 +487,7 @@ h3 {
 }
 
 .status-bar {
-  background: #f3f2f1;
+  background: #e0e0e0;
   padding: 6px;
   margin-top: 20px;
   border-radius: 4px;
@@ -495,8 +495,15 @@ h3 {
 
 .status-fill {
   height: 8px;
-  background: #0078d4;
+  background: #555;
   width: 0;
+}
+
+.status-text {
+  margin-top: 4px;
+  font-size: 0.9em;
+  text-align: center;
+  color: #333;
 }
 
 .finish-summary {


### PR DESCRIPTION
## Summary
- style the left sidebar with square corners
- use dark gray for sidebar links
- tweak subpage progress bar appearance and add progress text
- display tasks completed in the field wizard

## Testing
- `npm test`
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6878cdf7bb8c8322b3a80e47dd40751a