### PR TITLE
Add back navigation and improved layout for field subpages

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -38,4 +38,5 @@ export default {
   home: 'Home',
   skip: 'Skip',
   allCommonComplete: 'All common fields completed',
+  details: 'Details',
 };

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -454,6 +454,20 @@ function App() {
     }
   }
 
+  function applyRecommendedValue(cf: CompanyField) {
+    const key = fieldKey(cf.field);
+    setFormData(f => ({ ...f, [key]: recommendedCode(cf.recommended) }));
+  }
+
+  function handleRecommended(cf: CompanyField) {
+    if (cf.recommended) {
+      const rec = recommendedCode(cf.recommended);
+      if (window.confirm(`Suggested value: ${rec}. Use it?`)) {
+        applyRecommendedValue(cf);
+      }
+    }
+  }
+
   async function generateCustomRapidStart(): Promise<void> {
     logDebug('Preparing RapidStart XML');
     const xml = `<?xml version="1.0"?>\n<CustomRapidStart>\n  <CompanyName>${formData.companyName}</CompanyName>\n  <Address>${formData.address}</Address>\n  <Country>${formData.country}</Country>\n  <PostingGroup>${formData.postingGroup}</PostingGroup>\n  <PaymentTerms>${formData.paymentTerms}</PaymentTerms>\n</CustomRapidStart>`;
@@ -580,35 +594,11 @@ function App() {
         </select>
       );
     }
-    const acceptRecommended = () => {
-      setFormData((f: FormData) => ({
-        ...f,
-        [key]: recommendedCode(cf.recommended),
-      }));
-    };
-
-    const handleRecommended = () => {
-      if (cf.recommended) {
-        const rec = recommendedCode(cf.recommended);
-        if (window.confirm(`Suggested value: ${rec}. Use it?`)) {
-          acceptRecommended();
-        }
-      }
-    };
 
     return (
       <>
         {inputEl}
-        {cf.recommended && (
-          <span
-            className="icon"
-            role="button"
-            title="Use recommended value"
-            onClick={handleRecommended}
-          >
-            ⭐
-          </span>
-        )}
+        {/* recommended icon moved to FieldSubPage */}
         <span
           className="icon"
           role="button"
@@ -780,6 +770,7 @@ function App() {
         <CompanyInfoPage
           fields={companyFields}
           renderInput={renderInput}
+          handleRecommended={handleRecommended}
           next={next}
           back={() => setStep(1)}
           progress={companyProgress}
@@ -811,6 +802,7 @@ function App() {
         <GLSetupPage
           fields={glFields}
           renderInput={renderInput}
+          handleRecommended={handleRecommended}
           next={next}
           back={back}
           progress={glProgress}
@@ -821,6 +813,7 @@ function App() {
         <SalesReceivablesPage
           fields={srFields}
           renderInput={renderInput}
+          handleRecommended={handleRecommended}
           next={next}
           back={back}
           progress={srProgress}

--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { CompanyField } from '../types';
 
+import strings from '../../res/strings';
+
 interface Props {
   field: CompanyField;
   renderInput: (cf: CompanyField) => React.ReactNode;
   onConfirm: () => void;
   onSkip: () => void;
+  onBack: () => void;
+  onRecommended?: () => void;
   confirmLabel?: string;
   confirmed?: boolean;
 }
@@ -15,6 +19,8 @@ function FieldSubPage({
   renderInput,
   onConfirm,
   onSkip,
+  onBack,
+  onRecommended,
   confirmLabel = 'Confirm',
   confirmed,
 }: Props) {
@@ -25,14 +31,26 @@ function FieldSubPage({
           <div className="confirmed-banner">Confirmed!</div>
         )}
         <div className="question"><strong>{cf.question}</strong></div>
-        <div className="field-ref">{cf.field}</div>
-        {cf.recommended && (
-          <div className="recommended">Recommended: {cf.recommended}</div>
-        )}
         <div className="input-area">{renderInput(cf)}</div>
+        <div className="field-ref">{cf.field}</div>
+        <div className="details-divider">{strings.details}</div>
+        {cf.recommended && (
+          <div className="recommended">
+            Recommended: {cf.recommended}{' '}
+            <span
+              className="icon"
+              role="button"
+              title="Use recommended value"
+              onClick={onRecommended}
+            >
+              ⭐
+            </span>
+          </div>
+        )}
       </div>
       <div className="subpage-considerations">{cf.considerations}</div>
       <div className="nav">
+        <button className="next-btn" onClick={onBack}>{strings.back}</button>
         <button className="next-btn" onClick={onConfirm}>{confirmLabel}</button>
         <button className="skip-btn" onClick={onSkip}>Skip</button>
       </div>

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -11,9 +11,10 @@ interface Props {
   back: () => void;
   progress: boolean[];
   setProgress: (arr: boolean[]) => void;
+  handleRecommended: (cf: CompanyField) => void;
 }
 
-function FieldWizard({ title, fields, renderInput, next, back, progress, setProgress }: Props) {
+function FieldWizard({ title, fields, renderInput, next, back, progress, setProgress, handleRecommended }: Props) {
   const common = fields.filter(f => f.common === 'common');
   const sometimes = fields.filter(f => f.common === 'sometimes');
   const unlikely = fields.filter(f => f.common === 'unlikely');
@@ -61,6 +62,10 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
     if (idx === -1) setStage('finish');
     else setCIdx(idx);
   }
+  function backCommon() {
+    if (cIdx > 0) setCIdx(cIdx - 1);
+    else back();
+  }
 
   function reviewSometimes() {
     setStage('sometimes');
@@ -79,6 +84,10 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
       setStage('finish');
     }
   }
+  function backSome() {
+    if (sIdx > 0) setSIdx(sIdx - 1);
+    else setStage('finish');
+  }
 
   function reviewUnlikely() {
     setStage('unlikely');
@@ -96,6 +105,10 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
       setUDone(true);
       next();
     }
+  }
+  function backUnlikely() {
+    if (uIdx > 0) setUIdx(uIdx - 1);
+    else setStage('finish');
   }
 
   function skipSometimes() {
@@ -116,6 +129,8 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
           field={common[cIdx]}
           renderInput={renderInput}
           onConfirm={confirmCommon}
+          onBack={backCommon}
+          onRecommended={() => handleRecommended(common[cIdx])}
           onSkip={skipCommon}
           confirmLabel={cIdx === common.length - 1 ? 'Confirm and Finish' : 'Confirm'}
           confirmed={progress[cIdx]}
@@ -127,6 +142,8 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
           field={sometimes[sIdx]}
           renderInput={renderInput}
           onConfirm={confirmSome}
+          onBack={backSome}
+          onRecommended={() => handleRecommended(sometimes[sIdx])}
           onSkip={skipSome}
           confirmLabel={sIdx === sometimes.length - 1 ? 'Confirm and Finish' : 'Confirm'}
         />
@@ -137,6 +154,8 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
           field={unlikely[uIdx]}
           renderInput={renderInput}
           onConfirm={confirmUnlikelyField}
+          onBack={backUnlikely}
+          onRecommended={() => handleRecommended(unlikely[uIdx])}
           onSkip={skipUnlikelyField}
           confirmLabel={uIdx === unlikely.length - 1 ? 'Confirm and Finish' : 'Confirm'}
         />

--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -13,14 +13,16 @@ interface Props {
   back: () => void;
   progress: boolean[];
   setProgress: (arr: boolean[]) => void;
+  handleRecommended: (cf: CompanyField) => void;
 }
 
-function CompanyInfoPage({ fields, renderInput, next, back, progress, setProgress }: Props) {
+function CompanyInfoPage({ fields, renderInput, next, back, progress, setProgress, handleRecommended }: Props) {
   return (
     <FieldWizard
       title={strings.companyInfo}
       fields={fields}
       renderInput={renderInput}
+      handleRecommended={handleRecommended}
       next={next}
       back={back}
       progress={progress}

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -11,14 +11,16 @@ interface Props {
   back: () => void;
   progress: boolean[];
   setProgress: (arr: boolean[]) => void;
+  handleRecommended: (cf: CompanyField) => void;
 }
 
-function GLSetupPage({ fields, renderInput, next, back, progress, setProgress }: Props) {
+function GLSetupPage({ fields, renderInput, next, back, progress, setProgress, handleRecommended }: Props) {
   return (
     <FieldWizard
       title={strings.generalLedgerSetup}
       fields={fields}
       renderInput={renderInput}
+      handleRecommended={handleRecommended}
       next={next}
       back={back}
       progress={progress}

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -11,14 +11,16 @@ interface Props {
   back: () => void;
   progress: boolean[];
   setProgress: (arr: boolean[]) => void;
+  handleRecommended: (cf: CompanyField) => void;
 }
 
-function SalesReceivablesPage({ fields, renderInput, next, back, progress, setProgress }: Props) {
+function SalesReceivablesPage({ fields, renderInput, next, back, progress, setProgress, handleRecommended }: Props) {
   return (
     <FieldWizard
       title={strings.salesReceivablesSetup}
       fields={fields}
       renderInput={renderInput}
+      handleRecommended={handleRecommended}
       next={next}
       back={back}
       progress={progress}

--- a/style.css
+++ b/style.css
@@ -496,6 +496,14 @@ h3 {
   color: #555;
 }
 
+.details-divider {
+  margin-top: 10px;
+  padding-top: 4px;
+  border-top: 1px solid #ccc;
+  font-weight: 600;
+  font-size: 0.9em;
+}
+
 .confirmed-banner {
   background: #008000;
   color: #fff;


### PR DESCRIPTION
## Summary
- add `details` label for localization
- update FieldSubPage to show back button and recommended icon next to recommendation text
- move field name below input and add `Details` divider
- support recommended handler and back navigation in FieldWizard
- expose recommended handler from App and pass through pages
- tweak stylesheet for new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878d020d47483228142293990cf0e61