### PR TITLE
Update basic page and add review summary

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -3,7 +3,7 @@ export default {
   splashWelcome: 'Welcome! This wizard will help you configure Dynamics 365 Business Central.',
   getStarted: 'Get Started',
   basicInfoTitle: 'Basic Information',
-  basicInfo: 'Basic Information',
+  basicInfo: 'Basics',
   companyNameLabel: 'Company Name',
   industryLabel: 'Industry',
   websiteLabel: 'Website URL',
@@ -39,4 +39,6 @@ export default {
   skip: 'Skip',
   allCommonComplete: 'All common fields completed',
   details: 'Details',
+  finishButton: 'Finish',
+  bcFieldNameLabel: 'Business Central Field Name:',
 };

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,6 +15,7 @@ import SalesReceivablesPage from './pages/SalesReceivablesPage';
 import CustomersPage from './pages/CustomersPage';
 import VendorsPage from './pages/VendorsPage';
 import ItemsPage from './pages/ItemsPage';
+import ReviewPage from './pages/ReviewPage';
 import BCLogo from './images/Examples/BC Logo.png';
 import strings from '../res/strings';
 import { CompanyField, BasicInfo } from './types';
@@ -629,7 +630,7 @@ function App() {
     if (step === 2) return 'basic';
     if ([3, 4, 5, 6, 7].includes(step)) return 'config';
     if ([8, 9, 10].includes(step)) return 'master';
-    if (step === 11) return 'review';
+    if (step === 12) return 'review';
     return '';
   })();
 
@@ -683,10 +684,46 @@ function App() {
               {configOpen && (
                 <ul>
                   <li onClick={() => setStep(3)}>{strings.companyInfo}</li>
+                  {step === 3 && (
+                    <ul className="subnav">
+                      {companyFields
+                        .filter(f => f.common === 'common')
+                        .map((f, i) => (
+                          <li key={f.field}>
+                            {companyProgress[i] && <span className="check">✔</span>}
+                            {f.field}
+                          </li>
+                        ))}
+                    </ul>
+                  )}
                   <li onClick={() => setStep(4)}>Posting Information</li>
                   <li onClick={() => setStep(5)}>{strings.paymentTerms}</li>
                   <li onClick={() => setStep(6)}>{strings.generalLedgerSetup}</li>
+                  {step === 6 && (
+                    <ul className="subnav">
+                      {glFields
+                        .filter(f => f.common === 'common')
+                        .map((f, i) => (
+                          <li key={f.field}>
+                            {glProgress[i] && <span className="check">✔</span>}
+                            {f.field}
+                          </li>
+                        ))}
+                    </ul>
+                  )}
                   <li onClick={() => setStep(7)}>{strings.salesReceivablesSetup}</li>
+                  {step === 7 && (
+                    <ul className="subnav">
+                      {srFields
+                        .filter(f => f.common === 'common')
+                        .map((f, i) => (
+                          <li key={f.field}>
+                            {srProgress[i] && <span className="check">✔</span>}
+                            {f.field}
+                          </li>
+                        ))}
+                    </ul>
+                  )}
                 </ul>
               )}
             </div>
@@ -824,6 +861,14 @@ function App() {
           {step === 9 && <VendorsPage next={next} back={back} />}
           {step === 10 && <ItemsPage next={next} back={back} />}
           {step === 11 && (
+            <ReviewPage
+              fields={[...companyFields, ...glFields, ...srFields]}
+              formData={formData}
+              back={back}
+              next={next}
+            />
+          )}
+          {step === 12 && (
             <FinishPage
               generate={generateCustomRapidStart}
               back={back}

--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -32,21 +32,10 @@ function FieldSubPage({
         )}
         <div className="question"><strong>{cf.question}</strong></div>
         <div className="input-area">{renderInput(cf)}</div>
-        <div className="field-ref">{cf.field}</div>
         <div className="details-divider">{strings.details}</div>
-        {cf.recommended && (
-          <div className="recommended">
-            Recommended: {cf.recommended}{' '}
-            <span
-              className="icon"
-              role="button"
-              title="Use recommended value"
-              onClick={onRecommended}
-            >
-              ⭐
-            </span>
-          </div>
-        )}
+        <div className="field-ref">
+          <strong>{strings.bcFieldNameLabel}</strong> {cf.field}
+        </div>
       </div>
       <div className="subpage-considerations">{cf.considerations}</div>
       <div className="nav">

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -34,19 +34,22 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
   const [uDone, setUDone] = useState(false);
 
 
-  const progressPct = common.length
-    ? Math.round((progress.filter(Boolean).length / common.length) * 100)
-    : 100;
+  const stageProgress = (() => {
+    if (stage === 'common') {
+      return { done: progress.filter(Boolean).length, total: common.length };
+    }
+    if (stage === 'sometimes') {
+      return { done: sIdx, total: sometimes.length };
+    }
+    if (stage === 'unlikely') {
+      return { done: uIdx, total: unlikely.length };
+    }
+    return { done: 0, total: 0 };
+  })();
 
-  if (stage === 'sometimes') {
-    currentConfirmed = sIdx;
-    currentTotal = sometimes.length;
-    progress = currentTotal ? Math.round((currentConfirmed / currentTotal) * 100) : 100;
-  } else if (stage === 'unlikely') {
-    currentConfirmed = uIdx;
-    currentTotal = unlikely.length;
-    progress = currentTotal ? Math.round((currentConfirmed / currentTotal) * 100) : 100;
-  }
+  const progressPct = stageProgress.total
+    ? Math.round((stageProgress.done / stageProgress.total) * 100)
+    : 100;
 
   function confirmCommon() {
     const arr = [...progress];
@@ -216,6 +219,9 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
 
         <div className="status-bar">
           <div className="status-fill" style={{ width: `${progressPct}%` }} />
+          <div className="status-text">
+            {stageProgress.done} of {stageProgress.total} tasks completed
+          </div>
         </div>
 
       )}

--- a/src/pages/BasicInfoPage.tsx
+++ b/src/pages/BasicInfoPage.tsx
@@ -99,9 +99,7 @@ function BasicInfoPage({
         <div className="field-considerations">{strings.descriptionHint}</div>
       </div>
       <div className="nav">
-        <button className="next-btn" onClick={back}>{strings.back}</button>
-        <button className="next-btn" onClick={next}>{strings.next}</button>
-        <button className="skip-btn" onClick={next}>{strings.skip}</button>
+        <button className="next-btn" onClick={next}>{strings.finishButton}</button>
       </div>
     </div>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,18 +8,21 @@ interface Props {
 function HomePage({ next }: Props) {
   return (
     <div className="splash-screen">
-      <div className="splash-content">
-        <h1>{strings.appTitle}</h1>
-        <p>{strings.splashWelcome}</p>
-        <button className="next-btn" onClick={next}>
-          {strings.getStarted}
-        </button>
+      <div className="splash-inner">
+        <div className="splash-content">
+          <h1>{strings.appTitle}</h1>
+          <p>{strings.splashWelcome}</p>
+          <button className="next-btn" onClick={next}>
+            {strings.getStarted}
+          </button>
+        </div>
+        <img
+          className="splash-image"
+          src={GettingStartImage}
+          alt="Getting started"
+        />
       </div>
-      <img
-        className="splash-image"
-        src={GettingStartImage}
-        alt="Getting started"
-      />
+      <p className="splash-terms">Use of this tool is subject to standard terms of service. ExampleCo is not responsible for any data loss.</p>
     </div>
   );
 }

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import strings from '../../res/strings';
+import { fieldKey } from '../utils/helpers';
+import { CompanyField } from '../types';
+
+interface Props {
+  fields: CompanyField[];
+  formData: { [key: string]: any };
+  back: () => void;
+  next: () => void;
+}
+
+function ReviewPage({ fields, formData, back, next }: Props) {
+  const map: Record<string, string> = {};
+  fields.forEach(f => {
+    map[fieldKey(f.field)] = f.field;
+  });
+  const entries = Object.keys(formData).map(k => ({
+    name: map[k] || k,
+    value: formData[k],
+  }));
+
+  return (
+    <div>
+      <h2>{strings.review}</h2>
+      <ul>
+        {entries.map(e => (
+          <li key={e.name}>
+            <strong>{e.name}:</strong> {String(e.value)}
+          </li>
+        ))}
+      </ul>
+      <div className="nav">
+        <button className="next-btn" onClick={back}>{strings.back}</button>
+        <button className="next-btn" onClick={next}>I'm good for now</button>
+      </div>
+    </div>
+  );
+}
+
+export default ReviewPage;

--- a/style.css
+++ b/style.css
@@ -86,6 +86,11 @@ button:hover {
   white-space: pre-wrap;
 }
 .splash-screen {
+  background: #fff;
+  padding: 30px;
+}
+
+.splash-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -125,6 +130,12 @@ button:hover {
 
 .splash-button:hover {
   background-color: #e5e5e5;
+}
+
+.splash-terms {
+  font-size: 0.8em;
+  color: #555;
+  margin-top: 10px;
 }
 
 h3 {
@@ -435,6 +446,19 @@ h3 {
   background: var(--bc-blue);
   width: 0;
   transition: width 0.3s;
+}
+
+.subnav {
+  margin-left: 15px;
+}
+
+.subnav li {
+  font-size: 0.9em;
+}
+
+.check {
+  color: green;
+  margin-right: 4px;
 }
 
 /* Big next button and skip link */


### PR DESCRIPTION
## Summary
- tweak Home splash screen layout and add terms of use
- update Basic Info page navigation
- show field names under details in subpages
- show progress text in Field Wizard
- display subpages with check marks in sidebar
- add Review page and wire up step after master data

## Testing
- `npm test`
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6878d6f56f488322ae5064a0bd4c4acf