### PR TITLE
UI tweaks for help and progress text

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -26,7 +26,7 @@ export default {
   vendors: 'Vendors',
   items: 'Items',
   search: 'Search',
-  help: 'Help',
+  help: 'Get Help from your Partner',
   review: 'Review',
   configurationData: 'Configuration Data',
   masterData: 'Master Data',

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -787,7 +787,10 @@ function App() {
           <div className="topbar">
             <div className="actions">
               <span>{strings.search}</span>
-              <span>{strings.help}</span>
+              <button className="help-btn">
+                <span className="icon">?</span>
+                {strings.help}
+              </button>
             </div>
             <div className="progress-area">
               <div className="progress-slider">

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -224,14 +224,9 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
       )}
 
       {(stage === 'common' || stage === 'sometimes' || stage === 'unlikely') && (
-
-        <div className="status-bar">
-          <div className="status-fill" style={{ width: `${progressPct}%` }} />
-          <div className="status-text">
-            {stageProgress.done} of {stageProgress.total} tasks completed
-          </div>
+        <div className="completion-text">
+          {stageProgress.done} of {stageProgress.total} tasks completed
         </div>
-
       )}
     </div>
   );

--- a/style.css
+++ b/style.css
@@ -265,6 +265,22 @@ h3 {
   cursor: pointer;
 }
 
+.help-btn {
+  background: #fff;
+  color: var(--bc-text);
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 4px 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.help-btn:hover {
+  background: var(--bc-gray);
+}
+
 .ai-btn:hover {
   background-color: var(--bc-teal-dark);
 }
@@ -347,6 +363,16 @@ h3 {
   cursor: pointer;
   color: var(--bc-blue);
   margin-bottom: 4px;
+  padding: 4px 8px;
+  border: 1px solid var(--bc-blue);
+  border-radius: 4px;
+  background: #fff;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.home-link:hover {
+  background: var(--bc-gray);
 }
 
 
@@ -556,21 +582,8 @@ h3 {
   color: #555;
 }
 
-.status-bar {
-  background: #e0e0e0;
-  padding: 6px;
+.completion-text {
   margin-top: 20px;
-  border-radius: 4px;
-}
-
-.status-fill {
-  height: 8px;
-  background: #555;
-  width: 0;
-}
-
-.status-text {
-  margin-top: 4px;
   font-size: 0.9em;
   text-align: center;
   color: #333;


### PR DESCRIPTION
## Summary
- restyle the `Home` link to match the site theme
- change Help text to 'Get Help from your Partner'
- add new `help-btn` style and question mark icon
- replace progress meter with simple completion text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e19a110c8322809e94124bb40d8e