### PR TITLE
Rename Basic Info nav item

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -724,7 +724,7 @@ function App() {
             <div className="group">
               <div className="group-title">{strings.basicInfo}</div>
               <ul>
-                <li onClick={() => setStep(2)}>{strings.basicInfo}</li>
+                <li onClick={() => setStep(2)}>{strings.basicInfoTitle}</li>
               </ul>
             </div>
             <div className="group">
@@ -810,9 +810,9 @@ function App() {
             </div>
             <div className="progress-area">
               <div className="progress-slider">
-                <div className={`progress-step ${currentGroup === 'basic' ? 'active' : ''}`}> 
+                <div className={`progress-step ${currentGroup === 'basic' ? 'active' : ''}`}>
                   <div className="circle">1</div>
-                  <span>{strings.basicInfo}</span>
+                  <span>{strings.basicInfoTitle}</span>
                 </div>
                 <div className={`progress-step ${currentGroup === 'config' ? 'active' : ''}`}> 
                   <div className="circle">2</div>

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -40,7 +40,7 @@ function ConfigMenuPage({
         <div className="menu-grid">
           <div className="menu-box" onClick={goToBasicInfo}>
             <div className="icon" role="img" aria-label="Basic Info">ℹ️</div>
-            <div>{strings.basicInfo}</div>
+            <div>{strings.basicInfoTitle}</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rename the Basic Info link text in the navigation and menu to "Basic Information"
- adjust progress bar label accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878e41e2a708322bad760b6fb3188bd