### PR TITLE
Include input value in AI prompt

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -413,12 +413,14 @@ function App() {
   function openAIDialog(
     fieldName: string,
     key: string,
+    currentValue: string,
     considerations: string = ''
   ): void {
     let prompt =
       'We are configuring Dynamics Business Central\n\n' +
       'We are looking for a recommended value for the field:\n\n' +
       `${fieldName}\n\n` +
+      `The current value is: ${currentValue || '(blank)'}\n\n` +
       'Please us the following information to help determine the recommended value\n--------------\n';
 
     const parts: string[] = [];
@@ -657,7 +659,7 @@ function App() {
           type="button"
           className="ai-btn"
           title="Ask AI"
-          onClick={() => openAIDialog(cf.field, key, cf.considerations)}
+          onClick={() => openAIDialog(cf.field, key, val, cf.considerations)}
         >
           <img src={copilotIcon} alt="" className="copilot-icon" />
           Ask AI to help

--- a/src/pages/PaymentTermsPage.tsx
+++ b/src/pages/PaymentTermsPage.tsx
@@ -6,7 +6,7 @@ interface Props {
   handleBlur: (e: any) => void;
   next: () => void;
   back: () => void;
-  askAI: (field: string, key: string, cons?: string) => void;
+  askAI: (field: string, key: string, value: string, cons?: string) => void;
   options: { code: string; description: string }[];
 }
 
@@ -44,7 +44,13 @@ function PaymentTermsPage({
             className="icon"
             role="button"
             title="Ask AI"
-            onClick={() => askAI(strings.paymentTermsLabel, 'paymentTerms')}
+            onClick={() =>
+              askAI(
+                strings.paymentTermsLabel,
+                'paymentTerms',
+                formData.paymentTerms || ''
+              )
+            }
           >
             🤖
           </span>

--- a/src/pages/PostingGroupsPage.tsx
+++ b/src/pages/PostingGroupsPage.tsx
@@ -6,7 +6,7 @@ interface Props {
   handleBlur: (e: any) => void;
   next: () => void;
   back: () => void;
-  askAI: (field: string, key: string, cons?: string) => void;
+  askAI: (field: string, key: string, value: string, cons?: string) => void;
 }
 
 function PostingGroupsPage({
@@ -34,7 +34,13 @@ function PostingGroupsPage({
             className="icon"
             role="button"
             title="Ask AI"
-            onClick={() => askAI(strings.generalPostingGroupLabel, 'postingGroup')}
+            onClick={() =>
+              askAI(
+                strings.generalPostingGroupLabel,
+                'postingGroup',
+                formData.postingGroup || ''
+              )
+            }
           >
             🤖
           </span>


### PR DESCRIPTION
## Summary
- update `openAIDialog` to receive the field's current value
- pass the current value when calling the AI help button
- update pages to send the value when invoking AI help

## Testing
- `npm test` *(fails: No tests yet)*
- `node node_modules/vite/bin/vite.js build` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e4a8b3c883228127f269bd6d53d9