### PR TITLE
Improve AI help dialog layout

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -999,13 +999,14 @@ function App() {
                 </div>
                 <div className="confidence"><strong>Confidence:</strong> {aiParsed.confidence}</div>
                 <div className="ai-answer">{aiParsed.reasoning}</div>
+            <label htmlFor="ai-extra">Additional Instructions</label>
             <textarea
+              id="ai-extra"
               value={aiExtra}
               onChange={e => setAiExtra(e.target.value)}
-              placeholder="Additional Instructions"
             />
-            <button className="next-btn" onClick={askAgain}>Ask AI Assistant</button>
-            <div className="nav">
+            <button className="go-btn" onClick={askAgain}>go</button>
+            <div className="nav modal-actions">
               <button className="next-btn" onClick={acceptSuggested}>Accept</button>
               <button className="next-btn" onClick={closeAIDialog}>Cancel</button>
             </div>

--- a/style.css
+++ b/style.css
@@ -325,6 +325,24 @@ h3 {
   margin-bottom: 10px;
 }
 
+/* Divider and spacing for modal actions */
+.modal-actions {
+  border-top: 1px solid #d0d0d0;
+  margin-top: 20px;
+  padding-top: 10px;
+}
+
+/* Simple go button used to re-ask AI */
+.go-btn {
+  background: #000;
+  color: #fff;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+  margin-right: 10px;
+}
+
 .ai-answer {
   margin-top: 8px;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- adjust the AI modal layout
- add a divider before Accept/Cancel and space them out
- move the "Additional Instructions" label above the text area
- simplify Ask AI button to a small black "go" button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ea254c248322adb236ba7bbb429b