### PR TITLE
Adjust Additional Instructions textbox size

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1003,6 +1003,7 @@ function App() {
               value={aiExtra}
               onChange={e => setAiExtra(e.target.value)}
               placeholder="Additional Instructions"
+              rows={6}
             />
             <button className="next-btn" onClick={askAgain}>Ask AI Assistant</button>
             <div className="nav">

--- a/style.css
+++ b/style.css
@@ -321,7 +321,7 @@ h3 {
 
 .modal textarea {
   width: 100%;
-  height: 80px;
+  resize: none;
   margin-bottom: 10px;
 }
 


### PR DESCRIPTION
## Summary
- make the modal textarea non-resizable
- show six rows for the Additional Instructions field

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ea5e92c083228ed46111b4c15fc1