### PR TITLE
UI tweaks for AI help dialog

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1012,7 +1012,6 @@ function App() {
               id="ai-extra"
               value={aiExtra}
               onChange={e => setAiExtra(e.target.value)}
-              placeholder="Additional Instructions"
               rows={6}
             />
             <button className="go-btn" onClick={askAgain}>SUGGEST AGAIN</button>

--- a/style.css
+++ b/style.css
@@ -345,7 +345,7 @@ h3 {
 }
 
 .ai-answer {
-  margin-top: 8px;
+  margin-top: 15px;
   white-space: pre-wrap;
   font-size: 0.9em;
 }
@@ -357,8 +357,12 @@ h3 {
   font-weight: bold;
 }
 
+#ai-extra {
+  padding-right: 20px;
+}
+
 .suggested-box {
-  border: 2px solid var(--bc-blue);
+  border: 2px solid green;
   padding: 10px;
   margin-bottom: 10px;
   text-align: center;


### PR DESCRIPTION
## Summary
- remove placeholder text in the AI instructions textarea
- space out the AI reasoning line and add right padding to the textarea
- make suggested value box green

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f3218c548322b5d5a3a4e2007b50