### PR TITLE
Add Review and Finish navigation

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -28,6 +28,7 @@ export default {
   search: 'Search',
   help: 'Get Help from your Partner',
   review: 'Review',
+  reviewAndFinish: 'Review and Finish',
   configurationData: 'Configuration Data',
   masterData: 'Master Data',
   finishTitle: 'Finish',

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -845,8 +845,14 @@ function App() {
                   </li>
                 </ul>
               )}
-          </div>
-          </nav>
+            </div>
+            <div className="group">
+              <div className="group-title">{strings.reviewAndFinish}</div>
+              <ul>
+                <li onClick={() => setStep(12)}>{strings.reviewAndFinish}</li>
+              </ul>
+            </div>
+            </nav>
         </aside>
         <div className="content">
           <div className="topbar">
@@ -871,9 +877,9 @@ function App() {
                   <div className="circle">3</div>
                   <span>{strings.masterData}</span>
                 </div>
-                <div className={`progress-step ${currentGroup === 'review' ? 'active' : ''}`}> 
+                <div className={`progress-step ${currentGroup === 'review' ? 'active' : ''}`}>
                   <div className="circle">4</div>
-                  <span>{strings.review}</span>
+                  <span>{strings.reviewAndFinish}</span>
                 </div>
               </div>
               <div className="progress-bar">


### PR DESCRIPTION
## Summary
- label last progress step as 'Review and Finish'
- add Review and Finish section to sidebar navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f4c381848322a964a241bcedcb3b