### PR TITLE
Enable review page navigation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -422,6 +422,10 @@ function App() {
     setStep(1);
   }
 
+  function goToReview(): void {
+    setStep(11);
+  }
+
   function openAIDialog(
     fieldName: string,
     key: string,
@@ -921,6 +925,7 @@ function App() {
           setProgress={setCompanyProgress}
           visited={companyVisited}
           setVisited={setCompanyVisited}
+          goToReview={goToReview}
         />
       )}
       {step === 4 && (
@@ -955,6 +960,7 @@ function App() {
           setProgress={setGlProgress}
           visited={glVisited}
           setVisited={setGlVisited}
+          goToReview={goToReview}
         />
       )}
       {step === 7 && (
@@ -968,6 +974,7 @@ function App() {
           setProgress={setSrProgress}
           visited={srVisited}
           setVisited={setSrVisited}
+          goToReview={goToReview}
         />
       )}
           {step === 8 && <CustomersPage next={next} back={back} />}

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -14,9 +14,22 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  goToReview: () => void;
 }
 
-function FieldWizard({ title, fields, renderInput, next, back, progress, setProgress, visited, setVisited, handleRecommended }: Props) {
+function FieldWizard({
+  title,
+  fields,
+  renderInput,
+  next,
+  back,
+  progress,
+  setProgress,
+  visited,
+  setVisited,
+  handleRecommended,
+  goToReview,
+}: Props) {
   const common = fields.filter(f => f.common === 'common');
   const sometimes = fields.filter(f => f.common === 'sometimes');
   const unlikely = fields.filter(f => f.common === 'unlikely');
@@ -79,8 +92,7 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
   }
 
   function reviewSometimes() {
-    setStage('sometimes');
-    setSIdx(0);
+    goToReview();
   }
   function confirmSome() {
     nextSome();
@@ -101,8 +113,7 @@ function FieldWizard({ title, fields, renderInput, next, back, progress, setProg
   }
 
   function reviewUnlikely() {
-    setStage('unlikely');
-    setUIdx(0);
+    goToReview();
   }
   function confirmUnlikelyField() {
     nextUnlikely();

--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -16,9 +16,21 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  goToReview: () => void;
 }
 
-function CompanyInfoPage({ fields, renderInput, next, back, progress, setProgress, visited, setVisited, handleRecommended }: Props) {
+function CompanyInfoPage({
+  fields,
+  renderInput,
+  next,
+  back,
+  progress,
+  setProgress,
+  visited,
+  setVisited,
+  handleRecommended,
+  goToReview,
+}: Props) {
   return (
     <FieldWizard
       title={strings.companyInfo}
@@ -31,6 +43,7 @@ function CompanyInfoPage({ fields, renderInput, next, back, progress, setProgres
       setProgress={setProgress}
       visited={visited}
       setVisited={setVisited}
+      goToReview={goToReview}
     />
   );
 }

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -14,9 +14,21 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  goToReview: () => void;
 }
 
-function GLSetupPage({ fields, renderInput, next, back, progress, setProgress, visited, setVisited, handleRecommended }: Props) {
+function GLSetupPage({
+  fields,
+  renderInput,
+  next,
+  back,
+  progress,
+  setProgress,
+  visited,
+  setVisited,
+  handleRecommended,
+  goToReview,
+}: Props) {
   return (
     <FieldWizard
       title={strings.generalLedgerSetup}
@@ -29,6 +41,7 @@ function GLSetupPage({ fields, renderInput, next, back, progress, setProgress, v
       setProgress={setProgress}
       visited={visited}
       setVisited={setVisited}
+      goToReview={goToReview}
     />
   );
 }

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -14,9 +14,21 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  goToReview: () => void;
 }
 
-function SalesReceivablesPage({ fields, renderInput, next, back, progress, setProgress, visited, setVisited, handleRecommended }: Props) {
+function SalesReceivablesPage({
+  fields,
+  renderInput,
+  next,
+  back,
+  progress,
+  setProgress,
+  visited,
+  setVisited,
+  handleRecommended,
+  goToReview,
+}: Props) {
   return (
     <FieldWizard
       title={strings.salesReceivablesSetup}
@@ -29,6 +41,7 @@ function SalesReceivablesPage({ fields, renderInput, next, back, progress, setPr
       setProgress={setProgress}
       visited={visited}
       setVisited={setVisited}
+      goToReview={goToReview}
     />
   );
 }


### PR DESCRIPTION
## Summary
- provide a dedicated goToReview prop in FieldWizard
- wire goToReview through CompanyInfoPage, GLSetupPage, and SalesReceivablesPage
- add goToReview handler in App to jump to step 11
- trigger goToReview when Review buttons are clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f43cc9e48322948ce4cf3daa4f47