### PR TITLE
Improve navigation button alignment

### DIFF
--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -26,6 +26,7 @@ function FieldSubPage({
   confirmLabel = 'Confirm',
   confirmed,
 }: Props) {
+  const isFinal = confirmLabel === 'Confirm and Finish';
   return (
     <div className="subpage-field">
       <div className="subpage-left">
@@ -39,11 +40,13 @@ function FieldSubPage({
         </div>
       </div>
       <div className="subpage-considerations">{cf.considerations}</div>
-      <div className="nav">
+      <div className={`nav${isFinal ? ' final' : ''}`}>
         <button className="next-btn" onClick={onBack}>{strings.back}</button>
         <button className="next-btn" onClick={onConfirm}>{confirmLabel}</button>
         <button className="skip-section-btn" onClick={onSkipSection}>{strings.skipSection}</button>
-        <button className="skip-btn" onClick={onSkip}>Skip</button>
+        {!isFinal && (
+          <button className="skip-btn" onClick={onSkip}>Skip</button>
+        )}
       </div>
     </div>
   );

--- a/style.css
+++ b/style.css
@@ -30,10 +30,16 @@ label {
   display: flex;
   align-items: center;
 }
-.nav .skip-btn {
+.nav .skip-section-btn {
   margin-left: auto;
 }
-.nav .skip-section-btn {
+.nav .skip-btn {
+  margin-left: 10px;
+}
+.nav.final .next-btn {
+  margin-left: auto;
+}
+.nav.final .skip-section-btn {
   margin-left: 10px;
 }
 


### PR DESCRIPTION
## Summary
- align Skip Section next to Skip and show Confirm and Finish at the end
- hide Skip button on final field subpages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878fef293488322b017f452e53a2b5d