### PR TITLE
Add review step after skipping optional fields

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1023,6 +1023,7 @@ function App() {
           setProgress={setCompanyProgress}
           visited={companyVisited}
           setVisited={setCompanyVisited}
+          formData={formData}
           onShowSometimes={() => setShowCompanySometimes(true)}
           goToFieldIndex={companyFieldIdx}
         />
@@ -1059,6 +1060,7 @@ function App() {
           setProgress={setGlProgress}
           visited={glVisited}
           setVisited={setGlVisited}
+          formData={formData}
           onShowSometimes={() => setShowGLSometimes(true)}
           goToFieldIndex={glFieldIdx}
         />
@@ -1074,6 +1076,7 @@ function App() {
           setProgress={setSrProgress}
           visited={srVisited}
           setVisited={setSrVisited}
+          formData={formData}
           onShowSometimes={() => setShowSRSometimes(true)}
           goToFieldIndex={srFieldIdx}
         />

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { CompanyField } from '../types';
 import FieldSubPage from './FieldSubPage';
+import ReviewPage from '../pages/ReviewPage';
 import strings from '../../res/strings';
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  formData: { [key: string]: any };
   onShowSometimes?: () => void;
   /**
    * Optional index of a field to jump to when the wizard renders.
@@ -36,6 +38,7 @@ function FieldWizard({
   visited,
   setVisited,
   handleRecommended,
+  formData,
   onShowSometimes,
   goToFieldIndex,
 }: Props) {
@@ -44,7 +47,7 @@ function FieldWizard({
   const sometimes = fields.filter(f => f.common === 'sometimes');
   const unlikely = fields.filter(f => f.common === 'unlikely');
 
-  type Stage = 'common' | 'finish' | 'sometimes' | 'unlikely';
+  type Stage = 'common' | 'finish' | 'sometimes' | 'unlikely' | 'review';
   const [stage, setStage] = useState<Stage>(() =>
     progress.every(Boolean) ? 'finish' : 'common'
   );
@@ -57,6 +60,10 @@ function FieldWizard({
   const [uIdx, setUIdx] = useState(0);
   const [sDone, setSDone] = useState(false);
   const [uDone, setUDone] = useState(false);
+
+  function openReview() {
+    setStage('review');
+  }
 
   useEffect(() => {
     if (goToFieldIndex !== undefined && goToFieldIndex !== null) {
@@ -126,7 +133,7 @@ function FieldWizard({
     if (sIdx + 1 < sometimes.length) setSIdx(sIdx + 1);
     else {
       setSDone(true);
-      next();
+      openReview();
     }
   }
   function backSome() {
@@ -148,7 +155,7 @@ function FieldWizard({
     if (uIdx + 1 < unlikely.length) setUIdx(uIdx + 1);
     else {
       setUDone(true);
-      next();
+      openReview();
     }
   }
   function backUnlikely() {
@@ -158,12 +165,12 @@ function FieldWizard({
 
   function skipSometimes() {
     setSDone(true);
-    next();
+    openReview();
   }
 
   function skipUnlikely() {
     setUDone(true);
-    next();
+    openReview();
   }
 
   return (
@@ -244,6 +251,15 @@ function FieldWizard({
 
           {/* No other actions when skipping */}
         </div>
+      )}
+
+      {stage === 'review' && (
+        <ReviewPage
+          fields={fields}
+          formData={formData}
+          back={() => setStage('finish')}
+          next={next}
+        />
       )}
 
       {(stage === 'common' || stage === 'sometimes' || stage === 'unlikely') && (

--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -16,6 +16,7 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  formData: { [key: string]: any };
   onShowSometimes: () => void;
   goToFieldIndex?: number | null;
 }
@@ -30,6 +31,7 @@ function CompanyInfoPage({
   visited,
   setVisited,
   handleRecommended,
+  formData,
   onShowSometimes,
   goToFieldIndex,
 }: Props) {
@@ -46,6 +48,7 @@ function CompanyInfoPage({
       setProgress={setProgress}
       visited={visited}
       setVisited={setVisited}
+      formData={formData}
       onShowSometimes={onShowSometimes}
       goToFieldIndex={goToFieldIndex}
     />

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -14,6 +14,7 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  formData: { [key: string]: any };
   onShowSometimes: () => void;
   goToFieldIndex?: number | null;
 }
@@ -28,6 +29,7 @@ function GLSetupPage({
   visited,
   setVisited,
   handleRecommended,
+  formData,
   onShowSometimes,
   goToFieldIndex,
 }: Props) {
@@ -44,6 +46,7 @@ function GLSetupPage({
       setProgress={setProgress}
       visited={visited}
       setVisited={setVisited}
+      formData={formData}
       onShowSometimes={onShowSometimes}
       goToFieldIndex={goToFieldIndex}
     />

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -11,13 +11,9 @@ interface Props {
 }
 
 function ReviewPage({ fields, formData, back, next }: Props) {
-  const map: Record<string, string> = {};
-  fields.forEach(f => {
-    map[fieldKey(f.field)] = f.field;
-  });
-  const entries = Object.keys(formData).map(k => ({
-    name: map[k] || k,
-    value: formData[k],
+  const entries = fields.map(f => ({
+    name: f.field,
+    value: formData[fieldKey(f.field)],
   }));
 
   return (

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -14,6 +14,7 @@ interface Props {
   visited: boolean[];
   setVisited: (arr: boolean[]) => void;
   handleRecommended: (cf: CompanyField) => void;
+  formData: { [key: string]: any };
   onShowSometimes: () => void;
   goToFieldIndex?: number | null;
 }
@@ -28,6 +29,7 @@ function SalesReceivablesPage({
   visited,
   setVisited,
   handleRecommended,
+  formData,
   onShowSometimes,
   goToFieldIndex,
 }: Props) {
@@ -44,6 +46,7 @@ function SalesReceivablesPage({
       setProgress={setProgress}
       visited={visited}
       setVisited={setVisited}
+      formData={formData}
       onShowSometimes={onShowSometimes}
       goToFieldIndex={goToFieldIndex}
     />


### PR DESCRIPTION
## Summary
- show ReviewPage when skipping optional fields within FieldWizard
- update ReviewPage to only show passed fields
- pass `formData` through company setup pages
- wire up new prop in `app.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ffa9b44c8322912b70fea1ca6472