### PR TITLE
Add lightbulb tip style

### DIFF
--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { CompanyField } from '../types';
 
 import strings from '../../res/strings';
+import { LightbulbIcon } from './Icons';
 
 interface Props {
   field: CompanyField;
@@ -52,7 +53,14 @@ function FieldSubPage({
           <strong>{strings.bcFieldNameLabel}</strong> {cf.field}
         </div>
       </div>
-      <div className="subpage-considerations">{cf.considerations}</div>
+      {cf.considerations && (
+        <div className="subpage-considerations">
+          <LightbulbIcon className="tip-icon" />
+          <div>
+            <strong>Tip:</strong> {cf.considerations}
+          </div>
+        </div>
+      )}
       <div className={`nav${isFinal ? ' final' : ''}`}>
         <button className="next-btn" onClick={onBack}>{strings.back}</button>
         <button className="next-btn" onClick={onConfirm}>{confirmLabel}</button>

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -81,3 +81,17 @@ export function CubeIcon() {
   );
 }
 
+export function LightbulbIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      className={props.className ? props.className + ' menu-svg-icon' : 'menu-svg-icon'}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M9 18h6m-5 2h4M12 2a6 6 0 00-3 11v3h6v-3a6 6 0 00-3-11z" stroke="currentColor" strokeWidth="2" fill="none" />
+    </svg>
+  );
+}
+

--- a/style.css
+++ b/style.css
@@ -682,6 +682,20 @@ h3 {
   margin-top: 10px;
   font-size: 0.9em;
   color: #555;
+  background: var(--bc-gray);
+  border-left: 4px solid var(--bc-blue);
+  padding: 8px;
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.subpage-considerations .tip-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--bc-blue);
+  flex-shrink: 0;
+  cursor: default;
 }
 
 .completion-text {


### PR DESCRIPTION
## Summary
- show field considerations in a Tip box on subpages
- add a lightbulb icon component
- style the Tip area

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'vite/dist/node/cli.js')*

------
https://chatgpt.com/codex/tasks/task_e_687909375fe08322bbb9ec3c4bc0f735