### PR TITLE
Add AI recommendations to wizard pages

### DIFF
--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -18,6 +18,11 @@ interface Props {
   handleRecommended: (cf: CompanyField) => void;
   formData: { [key: string]: any };
   onShowSometimes?: () => void;
+  fetchAISuggestion: (
+    field: CompanyField,
+    currentValue: string
+  ) => Promise<{ suggested: string; confidence: string }>;
+  setFieldValue: (key: string, value: string) => void;
   /**
    * Optional index of a field to jump to when the wizard renders.
    * Only applies to the common fields stage.
@@ -40,6 +45,8 @@ function FieldWizard({
   handleRecommended,
   formData,
   onShowSometimes,
+  fetchAISuggestion,
+  setFieldValue,
   goToFieldIndex,
 }: Props) {
 
@@ -181,6 +188,9 @@ function FieldWizard({
         <FieldSubPage
           field={common[cIdx]}
           renderInput={renderInput}
+          formData={formData}
+          fetchAISuggestion={fetchAISuggestion}
+          setFieldValue={setFieldValue}
           onConfirm={confirmCommon}
           onBack={backCommon}
           onRecommended={() => handleRecommended(common[cIdx])}
@@ -195,6 +205,9 @@ function FieldWizard({
         <FieldSubPage
           field={sometimes[sIdx]}
           renderInput={renderInput}
+          formData={formData}
+          fetchAISuggestion={fetchAISuggestion}
+          setFieldValue={setFieldValue}
           onConfirm={confirmSome}
           onBack={backSome}
           onRecommended={() => handleRecommended(sometimes[sIdx])}
@@ -208,6 +221,9 @@ function FieldWizard({
         <FieldSubPage
           field={unlikely[uIdx]}
           renderInput={renderInput}
+          formData={formData}
+          fetchAISuggestion={fetchAISuggestion}
+          setFieldValue={setFieldValue}
           onConfirm={confirmUnlikelyField}
           onBack={backUnlikely}
           onRecommended={() => handleRecommended(unlikely[uIdx])}

--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -18,6 +18,11 @@ interface Props {
   handleRecommended: (cf: CompanyField) => void;
   formData: { [key: string]: any };
   onShowSometimes: () => void;
+  fetchAISuggestion: (
+    field: CompanyField,
+    currentValue: string
+  ) => Promise<{ suggested: string; confidence: string }>;
+  setFieldValue: (key: string, value: string) => void;
   goToFieldIndex?: number | null;
 }
 
@@ -33,6 +38,8 @@ function CompanyInfoPage({
   handleRecommended,
   formData,
   onShowSometimes,
+  fetchAISuggestion,
+  setFieldValue,
   goToFieldIndex,
 }: Props) {
   return (
@@ -50,6 +57,8 @@ function CompanyInfoPage({
       setVisited={setVisited}
       formData={formData}
       onShowSometimes={onShowSometimes}
+      fetchAISuggestion={fetchAISuggestion}
+      setFieldValue={setFieldValue}
       goToFieldIndex={goToFieldIndex}
     />
   );

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -16,6 +16,11 @@ interface Props {
   handleRecommended: (cf: CompanyField) => void;
   formData: { [key: string]: any };
   onShowSometimes: () => void;
+  fetchAISuggestion: (
+    field: CompanyField,
+    currentValue: string
+  ) => Promise<{ suggested: string; confidence: string }>;
+  setFieldValue: (key: string, value: string) => void;
   goToFieldIndex?: number | null;
 }
 
@@ -31,6 +36,8 @@ function GLSetupPage({
   handleRecommended,
   formData,
   onShowSometimes,
+  fetchAISuggestion,
+  setFieldValue,
   goToFieldIndex,
 }: Props) {
   return (
@@ -48,6 +55,8 @@ function GLSetupPage({
       setVisited={setVisited}
       formData={formData}
       onShowSometimes={onShowSometimes}
+      fetchAISuggestion={fetchAISuggestion}
+      setFieldValue={setFieldValue}
       goToFieldIndex={goToFieldIndex}
     />
   );

--- a/src/pages/PaymentTermsPage.tsx
+++ b/src/pages/PaymentTermsPage.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import strings from '../../res/strings';
 
 interface Props {
@@ -7,6 +8,13 @@ interface Props {
   next: () => void;
   back: () => void;
   askAI: (field: string, key: string, value: string, cons?: string) => void;
+  autoSuggest: (
+    field: string,
+    key: string,
+    value: string,
+    cons?: string
+  ) => Promise<{ suggested: string; confidence: string }>;
+  setFieldValue: (key: string, value: string) => void;
   options: { code: string; description: string }[];
 }
 
@@ -17,8 +25,26 @@ function PaymentTermsPage({
   next,
   back,
   askAI,
+  autoSuggest,
+  setFieldValue,
   options,
 }: Props) {
+  const [auto, setAuto] = React.useState<{ suggested: string; confidence: string } | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    autoSuggest(strings.paymentTermsLabel, 'paymentTerms', formData.paymentTerms || '')
+      .then(res => {
+        if (mounted) setAuto(res);
+      })
+      .catch(() => {});
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const showAuto =
+    auto && auto.suggested && /^(very high|high)$/i.test(auto.confidence || '');
   return (
     <div>
       <div className="section-header">{strings.paymentTerms}</div>
@@ -55,6 +81,19 @@ function PaymentTermsPage({
             <span className="icon">✨</span>
             Ask AI to help
           </button>
+          <div className="auto-suggest">
+            {showAuto && (
+              <>
+                <span>AI Recommends: {auto!.suggested}</span>
+                <button
+                  type="button"
+                  onClick={() => setFieldValue('paymentTerms', auto!.suggested)}
+                >
+                  Accept
+                </button>
+              </>
+            )}
+          </div>
         </div>
         <div className="field-considerations"></div>
       </div>

--- a/src/pages/PostingGroupsPage.tsx
+++ b/src/pages/PostingGroupsPage.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import strings from '../../res/strings';
 
 interface Props {
@@ -7,6 +8,13 @@ interface Props {
   next: () => void;
   back: () => void;
   askAI: (field: string, key: string, value: string, cons?: string) => void;
+  autoSuggest: (
+    field: string,
+    key: string,
+    value: string,
+    cons?: string
+  ) => Promise<{ suggested: string; confidence: string }>;
+  setFieldValue: (key: string, value: string) => void;
 }
 
 function PostingGroupsPage({
@@ -16,7 +24,30 @@ function PostingGroupsPage({
   next,
   back,
   askAI,
+  autoSuggest,
+  setFieldValue,
 }: Props) {
+  const [auto, setAuto] = React.useState<{ suggested: string; confidence: string } | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    autoSuggest(
+      strings.generalPostingGroupLabel,
+      'postingGroup',
+      formData.postingGroup || ''
+    )
+      .then(res => {
+        if (mounted) setAuto(res);
+      })
+      .catch(() => {});
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const showAuto =
+    auto && auto.suggested && /^(very high|high)$/i.test(auto.confidence || '');
+
   return (
     <div>
       <div className="section-header">{strings.postingGroups}</div>
@@ -45,6 +76,16 @@ function PostingGroupsPage({
             <span className="icon">✨</span>
             Ask AI to help
           </button>
+          <div className="auto-suggest">
+            {showAuto && (
+              <>
+                <span>AI Recommends: {auto!.suggested}</span>
+                <button type="button" onClick={() => setFieldValue('postingGroup', auto!.suggested)}>
+                  Accept
+                </button>
+              </>
+            )}
+          </div>
         </div>
         <div className="field-considerations"></div>
       </div>

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -16,6 +16,11 @@ interface Props {
   handleRecommended: (cf: CompanyField) => void;
   formData: { [key: string]: any };
   onShowSometimes: () => void;
+  fetchAISuggestion: (
+    field: CompanyField,
+    currentValue: string
+  ) => Promise<{ suggested: string; confidence: string }>;
+  setFieldValue: (key: string, value: string) => void;
   goToFieldIndex?: number | null;
 }
 
@@ -31,6 +36,8 @@ function SalesReceivablesPage({
   handleRecommended,
   formData,
   onShowSometimes,
+  fetchAISuggestion,
+  setFieldValue,
   goToFieldIndex,
 }: Props) {
   return (
@@ -48,6 +55,8 @@ function SalesReceivablesPage({
       setVisited={setVisited}
       formData={formData}
       onShowSometimes={onShowSometimes}
+      fetchAISuggestion={fetchAISuggestion}
+      setFieldValue={setFieldValue}
       goToFieldIndex={goToFieldIndex}
     />
   );

--- a/style.css
+++ b/style.css
@@ -669,6 +669,19 @@ h3 {
   color: #555;
 }
 
+.auto-suggest {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9em;
+  color: #555;
+}
+
+.auto-suggest button {
+  margin-left: 10px;
+}
+
 
 .confirmed-banner {
   background: var(--bc-teal);


### PR DESCRIPTION
## Summary
- build AI prompt utilities and fetch helper
- surface auto suggestions in FieldSubPage
- call auto suggestion functions from each wizard page
- style auto suggestion section

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module `vite/dist/node/cli.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6879089326788322949749e52c262449