### PR TITLE
UI tweaks to field wizard pages

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -888,6 +888,7 @@ function App() {
                         .map((f, i) => (
                           <li
                             key={f.field}
+                            className={companyFieldIdx === i ? 'active' : ''}
                             onClick={() => {
                               setCompanyFieldIdx(i);
                               setStep(3);
@@ -926,6 +927,7 @@ function App() {
                         .map((f, i) => (
                           <li
                             key={f.field}
+                            className={glFieldIdx === i ? 'active' : ''}
                             onClick={() => {
                               setGlFieldIdx(i);
                               setStep(6);
@@ -956,6 +958,7 @@ function App() {
                         .map((f, i) => (
                           <li
                             key={f.field}
+                            className={srFieldIdx === i ? 'active' : ''}
                             onClick={() => {
                               setSrFieldIdx(i);
                               setStep(7);
@@ -1091,6 +1094,7 @@ function App() {
           onShowSometimes={() => setShowCompanySometimes(true)}
           fetchAISuggestion={fetchAISuggestion}
           setFieldValue={setFieldValue}
+          onFieldIndexChange={setCompanyFieldIdx}
           goToFieldIndex={companyFieldIdx}
         />
       )}
@@ -1134,6 +1138,7 @@ function App() {
           onShowSometimes={() => setShowGLSometimes(true)}
           fetchAISuggestion={fetchAISuggestion}
           setFieldValue={setFieldValue}
+          onFieldIndexChange={setGlFieldIdx}
           goToFieldIndex={glFieldIdx}
         />
       )}
@@ -1152,6 +1157,7 @@ function App() {
           onShowSometimes={() => setShowSRSometimes(true)}
           fetchAISuggestion={fetchAISuggestion}
           setFieldValue={setFieldValue}
+          onFieldIndexChange={setSrFieldIdx}
           goToFieldIndex={srFieldIdx}
         />
       )}

--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -105,9 +105,6 @@ function FieldSubPage({
           </div>
         </div>
       )}
-      <div className="field-ref">
-        <strong>{strings.bcFieldNameLabel}</strong> {cf.field}
-      </div>
       <div className={`nav${isFinal ? ' final' : ''}`}>
         <button className="back-btn" onClick={onBack}>{strings.back}</button>
         <button className="next-btn" onClick={onConfirm}>{confirmLabel}</button>

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -23,6 +23,7 @@ interface Props {
     currentValue: string
   ) => Promise<{ suggested: string; confidence: string }>;
   setFieldValue: (key: string, value: string) => void;
+  onFieldIndexChange?: (index: number | null) => void;
   /**
    * Optional index of a field to jump to when the wizard renders.
    * Only applies to the common fields stage.
@@ -47,6 +48,7 @@ function FieldWizard({
   onShowSometimes,
   fetchAISuggestion,
   setFieldValue,
+  onFieldIndexChange,
   goToFieldIndex,
 }: Props) {
 
@@ -67,6 +69,13 @@ function FieldWizard({
   const [uIdx, setUIdx] = useState(0);
   const [sDone, setSDone] = useState(false);
   const [uDone, setUDone] = useState(false);
+
+  useEffect(() => {
+    if (onFieldIndexChange) {
+      if (stage === 'common') onFieldIndexChange(cIdx);
+      else onFieldIndexChange(null);
+    }
+  }, [cIdx, stage]);
 
   function openReview() {
     setStage('review');

--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -23,6 +23,7 @@ interface Props {
     currentValue: string
   ) => Promise<{ suggested: string; confidence: string }>;
   setFieldValue: (key: string, value: string) => void;
+  onFieldIndexChange: (index: number | null) => void;
   goToFieldIndex?: number | null;
 }
 
@@ -40,6 +41,7 @@ function CompanyInfoPage({
   onShowSometimes,
   fetchAISuggestion,
   setFieldValue,
+  onFieldIndexChange,
   goToFieldIndex,
 }: Props) {
   return (
@@ -59,6 +61,7 @@ function CompanyInfoPage({
       onShowSometimes={onShowSometimes}
       fetchAISuggestion={fetchAISuggestion}
       setFieldValue={setFieldValue}
+      onFieldIndexChange={onFieldIndexChange}
       goToFieldIndex={goToFieldIndex}
     />
   );

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -21,6 +21,7 @@ interface Props {
     currentValue: string
   ) => Promise<{ suggested: string; confidence: string }>;
   setFieldValue: (key: string, value: string) => void;
+  onFieldIndexChange: (index: number | null) => void;
   goToFieldIndex?: number | null;
 }
 
@@ -38,6 +39,7 @@ function GLSetupPage({
   onShowSometimes,
   fetchAISuggestion,
   setFieldValue,
+  onFieldIndexChange,
   goToFieldIndex,
 }: Props) {
   return (
@@ -57,6 +59,7 @@ function GLSetupPage({
       onShowSometimes={onShowSometimes}
       fetchAISuggestion={fetchAISuggestion}
       setFieldValue={setFieldValue}
+      onFieldIndexChange={onFieldIndexChange}
       goToFieldIndex={goToFieldIndex}
     />
   );

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -21,6 +21,7 @@ interface Props {
     currentValue: string
   ) => Promise<{ suggested: string; confidence: string }>;
   setFieldValue: (key: string, value: string) => void;
+  onFieldIndexChange: (index: number | null) => void;
   goToFieldIndex?: number | null;
 }
 
@@ -38,6 +39,7 @@ function SalesReceivablesPage({
   onShowSometimes,
   fetchAISuggestion,
   setFieldValue,
+  onFieldIndexChange,
   goToFieldIndex,
 }: Props) {
   return (
@@ -57,6 +59,7 @@ function SalesReceivablesPage({
       onShowSometimes={onShowSometimes}
       fetchAISuggestion={fetchAISuggestion}
       setFieldValue={setFieldValue}
+      onFieldIndexChange={onFieldIndexChange}
       goToFieldIndex={goToFieldIndex}
     />
   );

--- a/style.css
+++ b/style.css
@@ -500,6 +500,11 @@ h3 {
   background-color: var(--bc-gray);
 }
 
+.sidebar li.active {
+  background-color: var(--bc-gray);
+  font-weight: bold;
+}
+
 .content {
   flex-grow: 1;
   display: flex;
@@ -609,8 +614,9 @@ h3 {
 
 .back-btn {
   background-color: transparent;
-  color: var(--bc-text);
-  border: none;
+  color: var(--bc-teal);
+  border: 1px solid var(--bc-teal-dark);
+  border-radius: 16px;
   padding: 12px 24px;
   font-size: 1.1em;
   cursor: pointer;
@@ -657,12 +663,17 @@ h3 {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  min-height: calc(100vh - 200px);
 }
 
 .subpage-left {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+
+.question {
+  margin-bottom: 10px;
 }
 
 .input-area {
@@ -688,6 +699,9 @@ h3 {
   gap: 8px;
   font-size: 0.9em;
   color: #555;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #d0d0d0;
 }
 
 .auto-suggest button {
@@ -726,7 +740,7 @@ h3 {
 .subpage-field .nav {
   border-top: 1px solid #d0d0d0;
   padding-top: 10px;
-  margin-top: 20px;
+  margin-top: auto;
 }
 
 .completion-text {


### PR DESCRIPTION
## Summary
- restyle back button with teal border
- add spacing and divider around subpage inputs
- keep wizard navigation at the bottom
- remove Business Central field name label
- highlight active sub-step in the sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687912c54790832291e836c412d06d5d