### PR TITLE
UI improvement: unify progress bubble with content

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1023,17 +1023,19 @@ function App() {
               <span>{strings.search}</span>
               <button className="help-btn">{strings.help}</button>
             </div>
+          </div>
+          <div className="page-area">
             <div className="progress-area">
               <div className="progress-slider">
                 <div className={`progress-step ${currentGroup === 'basic' ? 'active' : ''}`}>
                   <div className="circle">1</div>
                   <span>{strings.basicInfoTitle}</span>
                 </div>
-                <div className={`progress-step ${currentGroup === 'config' ? 'active' : ''}`}> 
+                <div className={`progress-step ${currentGroup === 'config' ? 'active' : ''}`}>
                   <div className="circle">2</div>
                   <span>{strings.configurationData}</span>
                 </div>
-                <div className={`progress-step ${currentGroup === 'master' ? 'active' : ''}`}> 
+                <div className={`progress-step ${currentGroup === 'master' ? 'active' : ''}`}>
                   <div className="circle">3</div>
                   <span>{strings.masterData}</span>
                 </div>
@@ -1049,8 +1051,7 @@ function App() {
                 <div className="progress-bar-fill" style={{ width: `${progressPercent}%` }}></div>
               </div>
             </div>
-          </div>
-          <main className="main">
+            <main className="main">
             {step === 0 && <HomePage next={next} />}
             {step === 1 && (
               <ConfigMenuPage
@@ -1186,6 +1187,7 @@ function App() {
             />
           )}
           </main>
+          </div>
           {showAI && (
             <div className="modal-overlay" onClick={closeAIDialog}>
               <div className="modal" onClick={e => e.stopPropagation()}>

--- a/style.css
+++ b/style.css
@@ -556,11 +556,23 @@ h3 {
 }
 
 .progress-area {
+  padding: 10px;
+  border-bottom: 1px solid #d0d0d0;
+  border-radius: 16px 16px 0 0;
+}
+
+.page-area {
   margin-top: 8px;
   background: #fff;
-  padding: 10px;
   border-radius: 16px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.page-area .main {
+  border-radius: 0 0 16px 16px;
 }
 
 .progress-bar {


### PR DESCRIPTION
## Summary
- style progress area as part of a new `page-area` container
- wrap progress area and page content in this container in `App`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879134888dc8322adada37adea3e846