### PR TITLE
Fix overflow of AI dialog instructions textarea

### DIFF
--- a/style.css
+++ b/style.css
@@ -337,6 +337,7 @@ h3 {
 
 .modal textarea {
   width: 100%;
+  box-sizing: border-box;
   resize: none;
   margin-bottom: 10px;
 }


### PR DESCRIPTION
## Summary
- ensure AI dialog textareas fit the modal by using `box-sizing: border-box`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687915d1812883229916ddb0d7446f7b