### PR TITLE
Fix layout height to prevent cutoff

### DIFF
--- a/style.css
+++ b/style.css
@@ -410,7 +410,8 @@ h3 {
 /* Layout and navigation */
 .layout {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .sidebar {
@@ -510,6 +511,8 @@ h3 {
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .topbar {
@@ -639,6 +642,7 @@ h3 {
 .main {
   padding: 20px;
   flex-grow: 1;
+  overflow-y: auto;
 }
 
 .skip-btn {
@@ -676,7 +680,7 @@ h3 {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  min-height: calc(100vh - 200px);
+  flex-grow: 1;
 }
 
 .subpage-left {


### PR DESCRIPTION
## Summary
- ensure entire layout fills the viewport height
- prevent content from overflowing by adding scroll handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68791fe727408322b0b2cf6bdc2d2b9b