### PR TITLE
Fix mapFieldName to strip periods

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,7 +3,7 @@ export function fieldKey(name: string): string {
 }
 
 export function mapFieldName(name: string): string {
-  return name.replace(/\s+/g, '').replace(/-/g, '_');
+  return name.replace(/\s+/g, '').replace(/\./g, '').replace(/-/g, '_');
 }
 
 export function findFieldValue(obj: any, field: string): any {


### PR DESCRIPTION
## Summary
- handle periods in mapFieldName so fields like "Quote Nos." convert to "QuoteNos"

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879274869c08322b118abc24b6dee4f