### PR TITLE
Switch config data to new BC setup JSON

### DIFF
--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -1,4 +1,5 @@
 import { xmlToJson } from './xmlParsing';
+import type { ConfigQuestion } from './jsonParsing';
 
 export async function loadStartingData(): Promise<any> {
   const resp = await fetch('NAV27.0.US.ENU.STANDARD.xml');
@@ -16,8 +17,17 @@ export async function loadStartingData(): Promise<any> {
   } as any;
 }
 
-export async function loadConfigTables(): Promise<any> {
-  const resp = await fetch('/config_table_questions_common_with_lookup.json');
-  return await resp.json();
+export async function loadConfigTables(): Promise<ConfigQuestion[]> {
+  const resp = await fetch('/BC_Setup_All_Tables_and_Fields_grouped_ordered.json');
+  const data = await resp.json();
+  const fields: ConfigQuestion[] = [];
+  if (Array.isArray(data)) {
+    data.forEach(t => {
+      if (Array.isArray(t.Fields)) {
+        t.Fields.forEach((f: ConfigQuestion) => fields.push(f));
+      }
+    });
+  }
+  return fields;
 }
 


### PR DESCRIPTION
## Summary
- load setup data from `BC_Setup_All_Tables_and_Fields_grouped_ordered.json`
- flatten table structure when parsing config questions

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: React module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a2965af048322871c28f74057d772