### PR TITLE
Integrate Fluent UI controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "@fluentui/react": "^8.0.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@fluentui/react": "^8.0.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -4,6 +4,7 @@ import { fieldKey } from '../utils/helpers';
 
 import strings from '../../res/strings';
 import { LightbulbIcon, SparkleIcon } from './Icons';
+import { PrimaryButton, DefaultButton } from '@fluentui/react';
 
 interface Props {
   field: CompanyField;
@@ -109,11 +110,18 @@ function FieldSubPage({
       )}
       <div className="nav-spacer" />
       <div className={`nav${isFinal ? ' final' : ''}`}>
-        <button className="back-btn" onClick={onBack}>{strings.back}</button>
-        <button className="next-btn" onClick={onConfirm}>{confirmLabel}</button>
-        <button className="skip-section-btn" onClick={onSkipSection}>{strings.skipSection}</button>
+        <DefaultButton className="back-btn" onClick={onBack}>
+          {strings.back}
+        </DefaultButton>
+        <PrimaryButton className="next-btn" onClick={onConfirm}>
+          {confirmLabel}
+        </PrimaryButton>
+        <DefaultButton className="skip-section-btn" onClick={onSkipSection}>
+          {strings.skipSection}
+        </DefaultButton>
         {!isFinal && (
-          <button className="skip-btn" onClick={onSkip}>Skip</button>
+          <DefaultButton className="skip-btn" onClick={onSkip}
+            >Skip</DefaultButton>
         )}
       </div>
     </div>

--- a/src/pages/BasicInfoPage.tsx
+++ b/src/pages/BasicInfoPage.tsx
@@ -1,6 +1,12 @@
 import strings from '../../res/strings';
 import { BasicInfo } from '../types';
 import React, { useState } from 'react';
+import {
+  TextField,
+  Dropdown,
+  IDropdownOption,
+  PrimaryButton,
+} from '@fluentui/react';
 
 interface Props {
   formData: BasicInfo;
@@ -40,9 +46,22 @@ function BasicInfoPage({
 }: Props) {
   const [industries, setIndustries] = useState(initialIndustries);
 
-  function handleIndustryBlur(e: any) {
-    handleBlur(e);
-    const val = e.target.value.trim();
+  const industryOptions: IDropdownOption[] = industries.map(ind => ({
+    key: ind,
+    text: ind,
+  }));
+
+  function onIndustryChange(_e: any, option?: IDropdownOption): void {
+    const synthetic = {
+      target: { name: 'industry', value: option ? option.text : '' },
+    } as any;
+    handleChange(synthetic);
+  }
+
+  function onIndustryBlur(): void {
+    const val = (data.industry || '').trim();
+    const synthetic = { target: { name: 'industry', value: val } } as any;
+    handleBlur(synthetic);
     if (val && !industries.includes(val)) {
       setIndustries([...industries, val]);
     }
@@ -53,7 +72,7 @@ function BasicInfoPage({
       <div className="field-row">
         <div className="field-name">{strings.companyNameLabel}</div>
         <div className="field-input">
-          <input
+          <TextField
             name="companyName"
             value={data.companyName || ''}
             onChange={handleChange}
@@ -65,25 +84,19 @@ function BasicInfoPage({
       <div className="field-row">
         <div className="field-name">{strings.industryLabel}</div>
         <div className="field-input">
-          <input
-            list="industry-list"
-            name="industry"
-            value={data.industry || ''}
-            onChange={handleChange}
-            onBlur={handleIndustryBlur}
+          <Dropdown
+            selectedKey={data.industry || undefined}
+            onChange={onIndustryChange}
+            onBlur={onIndustryBlur}
+            options={industryOptions}
           />
-          <datalist id="industry-list">
-            {industries.map(ind => (
-              <option value={ind} key={ind} />
-            ))}
-          </datalist>
         </div>
         <div className="field-considerations" />
       </div>
       <div className="field-row">
         <div className="field-name">{strings.websiteLabel}</div>
         <div className="field-input">
-          <input
+          <TextField
             type="url"
             name="websiteUrl"
             value={data.websiteUrl || ''}
@@ -96,7 +109,8 @@ function BasicInfoPage({
       <div className="field-row">
         <div className="field-name">{strings.descriptionLabel}</div>
         <div className="field-input">
-          <textarea
+          <TextField
+            multiline
             name="description"
             rows={8}
             value={data.description || ''}
@@ -107,7 +121,7 @@ function BasicInfoPage({
         <div className="field-considerations">{strings.descriptionHint}</div>
       </div>
       <div className="nav">
-        <button className="next-btn" onClick={next}>{strings.finishButton}</button>
+        <PrimaryButton onClick={next} text={strings.finishButton} />
       </div>
     </div>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,6 @@
 import GettingStartImage from '../images/GettingStartImage.jpg';
 import strings from '../../res/strings';
+import { PrimaryButton } from '@fluentui/react';
 
 interface Props {
   next: () => void;
@@ -12,9 +13,7 @@ function HomePage({ next }: Props) {
         <div className="splash-content">
           <h1>{strings.appTitle}</h1>
           <p>{strings.splashWelcome}</p>
-          <button className="next-btn" onClick={next}>
-            {strings.getStarted}
-          </button>
+          <PrimaryButton onClick={next} text={strings.getStarted} />
         </div>
         <img
           className="splash-image"


### PR DESCRIPTION
## Summary
- add `@fluentui/react` dependency
- switch Home and Basic Info pages to Fluent UI components
- update Field subpage navigation buttons to use Fluent UI

## Testing
- `npm test`
- `npm install @fluentui/react@^8.0.0 --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687a2991d6508322b140129c7acbab3f