### PR TITLE
Add in-progress indicators

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -653,8 +653,11 @@ function App() {
   }
 
   const companyDone = companyProgress.length > 0 && companyProgress.every(Boolean);
+  const companyInProgress = !companyDone && companyProgress.some(Boolean);
   const glDone = glProgress.length > 0 && glProgress.every(Boolean);
+  const glInProgress = !glDone && glProgress.some(Boolean);
   const srDone = srProgress.length > 0 && srProgress.every(Boolean);
+  const srInProgress = !srDone && srProgress.some(Boolean);
   const configSectionDone =
     companyDone && glDone && srDone;
   const basicSectionDone = basicDone;
@@ -729,6 +732,9 @@ function App() {
                       setStep(3);
                     }}>
                     {companyDone && <span className="check">✔</span>}
+                    {!companyDone && companyInProgress && (
+                      <span className="progress-dot">•</span>
+                    )}
                     {strings.companyInfo}
                   </li>
                   {step === 3 && (
@@ -760,6 +766,9 @@ function App() {
                       setStep(4);
                     }}>
                     {glDone && <span className="check">✔</span>}
+                    {!glDone && glInProgress && (
+                      <span className="progress-dot">•</span>
+                    )}
                     {strings.generalLedgerSetup}
                   </li>
                   {step === 4 && (
@@ -791,6 +800,9 @@ function App() {
                       setStep(5);
                     }}>
                     {srDone && <span className="check">✔</span>}
+                    {!srDone && srInProgress && (
+                      <span className="progress-dot">•</span>
+                    )}
                     {strings.salesReceivablesSetup}
                   </li>
                   {step === 5 && (
@@ -920,8 +932,11 @@ function App() {
               goToItems={() => setStep(8)}
               back={back}
               companyDone={companyDone}
+              companyInProgress={companyInProgress}
               glDone={glDone}
+              glInProgress={glInProgress}
               srDone={srDone}
+              srInProgress={srInProgress}
               />
             )}
             {step === 2 && (

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -20,8 +20,11 @@ interface Props {
   goToItems: () => void;
   back: () => void;
   companyDone: boolean;
+  companyInProgress: boolean;
   glDone: boolean;
+  glInProgress: boolean;
   srDone: boolean;
+  srInProgress: boolean;
 }
 
 function ConfigMenuPage({
@@ -34,8 +37,11 @@ function ConfigMenuPage({
   goToItems,
   back,
   companyDone,
+  companyInProgress,
   glDone,
+  glInProgress,
   srDone,
+  srInProgress,
 }: Props) {
   return (
     <div>
@@ -68,6 +74,9 @@ function ConfigMenuPage({
             }}
           >
             {companyDone && <div className="checkmark">✔</div>}
+            {!companyDone && companyInProgress && (
+              <div className="progress-dot">•</div>
+            )}
             <CompanyIcon />
             <div>{strings.companyInfo}</div>
           </div>
@@ -80,6 +89,9 @@ function ConfigMenuPage({
             }}
           >
             {glDone && <div className="checkmark">✔</div>}
+            {!glDone && glInProgress && (
+              <div className="progress-dot">•</div>
+            )}
             <BookIcon />
             <div>{strings.generalLedgerSetup}</div>
           </div>
@@ -92,6 +104,9 @@ function ConfigMenuPage({
             }}
           >
             {srDone && <div className="checkmark">✔</div>}
+            {!srDone && srInProgress && (
+              <div className="progress-dot">•</div>
+            )}
             <CartIcon />
             <div>{strings.salesReceivablesSetup}</div>
           </div>

--- a/style.css
+++ b/style.css
@@ -253,6 +253,20 @@ h3 {
   justify-content: center;
   font-size: 14px;
 }
+.menu-box .progress-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: var(--bc-purple);
+  color: #fff;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
 .menu-section {
   margin-bottom: 30px;
 }
@@ -629,6 +643,10 @@ h3 {
 
 .check {
   color: var(--bc-teal);
+  margin-right: 4px;
+}
+.progress-dot {
+  color: var(--bc-purple);
   margin-right: 4px;
 }
 


### PR DESCRIPTION
## Summary
- show partial progress on menu boxes and left nav items
- add progress-dot styles
- track in-progress state in app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a30de42688322bf6f13336b8a91a2