### PR TITLE
Add schema-driven grid columns for currency and vendors

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -78,9 +78,7 @@ function App() {
   const [itemsDone, setItemsDone] = useState(false);
   const [currenciesDone, setCurrenciesDone] = useState(false);
   const [currencyRows, setCurrencyRows] = useState<Record<string, string>[]>([]);
-  const [companyFieldIdx, setCompanyFieldIdx] = useState<number | null>(null);
-  const [glFieldIdx, setGlFieldIdx] = useState<number | null>(null);
-  const [srFieldIdx, setSrFieldIdx] = useState<number | null>(null);
+  const [vendorRows, setVendorRows] = useState<Record<string, string>[]>([]);
   const [showCompanySometimes, setShowCompanySometimes] = useState(false);
   const [showGLSometimes, setShowGLSometimes] = useState(false);
   const [showSRSometimes, setShowSRSometimes] = useState(false);
@@ -238,6 +236,18 @@ function App() {
             description: c.Description?.['#text'] || '',
           })) || [];
         setCurrencies(currencies);
+
+        const vrows = findTableRows(data, 23) || [];
+        const vsimple = vrows.map(r => {
+          const obj: Record<string, string> = {};
+          Object.keys(r).forEach(k => {
+            let v: any = (r as any)[k];
+            if (v && typeof v === "object" && "#text" in v) v = v["#text"];
+            obj[k] = v !== undefined && v !== null ? String(v) : "";
+          });
+          return obj;
+        });
+        setVendorRows(vsimple);
 
         const rows = findTableRows(data, 4) || [];
         const simple = rows.map(r => {
@@ -1027,11 +1037,9 @@ function App() {
         />
       )}
           {step === 6 && <CustomersPage next={next} back={back} />}
-          {step === 7 && <VendorsPage next={next} back={back} />}
+          {step === 7 && <VendorsPage rows={vendorRows} next={next} back={back} />}
           {step === 8 && <ItemsPage next={next} back={back} />}
           {step === 9 && <CurrencyPage rows={currencyRows} next={next} back={back} />}
-          {step === 10 && (
-            <ReviewPage
               fields={[...companyFields, ...glFields, ...srFields]}
               formData={formData}
               back={back}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1040,6 +1040,8 @@ function App() {
           {step === 7 && <VendorsPage rows={vendorRows} next={next} back={back} />}
           {step === 8 && <ItemsPage next={next} back={back} />}
           {step === 9 && <CurrencyPage rows={currencyRows} next={next} back={back} />}
+          {step === 10 && (
+            <ReviewPage
               fields={[...companyFields, ...glFields, ...srFields]}
               formData={formData}
               back={back}

--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 import strings from '../../res/strings';
+import { getTableFields, TableField } from '../utils/schema';
 
 interface Props {
   rows: Record<string, string>[];
@@ -11,10 +12,20 @@ interface Props {
 }
 
 export default function CurrencyPage({ rows, next, back }: Props) {
+  const [fields, setFields] = useState<TableField[]>([]);
+
+  useEffect(() => {
+    getTableFields('Currency').then(setFields);
+  }, []);
+
   const columnDefs = useMemo(() => {
     if (!rows.length) return [];
-    return Object.keys(rows[0]).map(key => ({ headerName: key, field: key, sortable: true, filter: true }));
-  }, [rows]);
+    if (!fields.length)
+      return Object.keys(rows[0]).map(key => ({ headerName: key, field: key, sortable: true, filter: true }));
+    return fields
+      .filter(f => Object.prototype.hasOwnProperty.call(rows[0], f.xmlName))
+      .map(f => ({ headerName: f.name, field: f.xmlName, sortable: true, filter: true }));
+  }, [rows, fields]);
 
   return (
     <div>

--- a/src/pages/VendorsPage.tsx
+++ b/src/pages/VendorsPage.tsx
@@ -1,11 +1,43 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
 import strings from '../../res/strings';
-import ComingSoonPage from './ComingSoonPage';
+import { getTableFields, TableField } from '../utils/schema';
 
 interface Props {
+  rows: Record<string, string>[];
   next: () => void;
   back: () => void;
 }
 
-export default function VendorsPage(props: Props) {
-  return <ComingSoonPage {...props} title={strings.vendors} />;
+export default function VendorsPage({ rows, next, back }: Props) {
+  const [fields, setFields] = useState<TableField[]>([]);
+
+  useEffect(() => {
+    getTableFields('Vendor').then(setFields);
+  }, []);
+
+  const columnDefs = useMemo(() => {
+    if (!rows.length) return [];
+    if (!fields.length)
+      return Object.keys(rows[0]).map(key => ({ headerName: key, field: key, sortable: true, filter: true }));
+    return fields
+      .filter(f => Object.prototype.hasOwnProperty.call(rows[0], f.xmlName))
+      .map(f => ({ headerName: f.name, field: f.xmlName, sortable: true, filter: true }));
+  }, [rows, fields]);
+
+  return (
+    <div>
+      <div className="section-header">{strings.vendors}</div>
+      <div className="ag-theme-alpine" style={{ height: 400, width: '100%' }}>
+        <AgGridReact rowData={rows} columnDefs={columnDefs} defaultColDef={{ flex: 1, resizable: true }} />
+      </div>
+      <div className="nav">
+        <button className="back-btn" onClick={back}>{strings.back}</button>
+        <button className="next-btn" onClick={next}>{strings.next}</button>
+        <button className="skip-btn" onClick={next}>{strings.skip}</button>
+      </div>
+    </div>
+  );
 }

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,44 @@
+import { mapFieldName } from './helpers';
+
+let cache: any = null;
+let mappings: any = null;
+
+async function loadSchema() {
+  if (!cache) {
+    const resp = await fetch('/BC_Master_Tables_and_Fields_Complete.json');
+    cache = await resp.json();
+  }
+  return cache;
+}
+
+async function loadMappings() {
+  if (!mappings) {
+    try {
+      const resp = await fetch('/field_name_mappings.json');
+      mappings = await resp.json();
+    } catch {
+      mappings = {};
+    }
+  }
+  return mappings;
+}
+
+export interface TableField {
+  name: string;
+  xmlName: string;
+}
+
+export async function getTableFields(tableName: string): Promise<TableField[]> {
+  const [schema, map] = await Promise.all([loadSchema(), loadMappings()]);
+  if (Array.isArray(schema)) {
+    const table = schema.find((t: any) => t.Name === tableName);
+    if (table && Array.isArray(table.Fields)) {
+      return table.Fields.map((f: any) => {
+        const name = String(f['BC Field Name'] || f.Field);
+        const xmlName = map[name] || mapFieldName(name);
+        return { name, xmlName };
+      });
+    }
+  }
+  return [];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "module": "ESNext",
     "target": "es5",
-    "jsx": "react",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -11,7 +10,6 @@
     "rootDir": "src",
     "outDir": "dist",
     "jsx": "react-jsx"
-    
   },
   "include": ["src/**/*", "res/**/*"]
 }


### PR DESCRIPTION
## Summary
- create `schema.ts` helper to fetch table field definitions
- update currency grid to use schema fields
- add vendor grid mirroring currency grid
- load vendor rows from RapidStart XML and show vendor grid

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a37b5448c83228de0f7746d1ddde3