### PR TITLE
Improve Currency page UX

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -451,7 +451,11 @@ function App() {
     if (step === 6) setCustomersDone(true);
     if (step === 7) setVendorsDone(true);
     if (step === 8) setItemsDone(true);
-    if (step === 9) setCurrenciesDone(true);
+    if (step === 9) {
+      setCurrenciesDone(true);
+      setStep(1);
+      return;
+    }
     setStep(step + 1);
   }
 
@@ -981,6 +985,10 @@ function App() {
               glInProgress={glInProgress}
               srDone={srDone}
               srInProgress={srInProgress}
+              customersDone={customersDone}
+              vendorsDone={vendorsDone}
+              itemsDone={itemsDone}
+              currenciesDone={currenciesDone}
               />
             )}
             {step === 2 && (

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -27,6 +27,10 @@ interface Props {
   glInProgress: boolean;
   srDone: boolean;
   srInProgress: boolean;
+  customersDone: boolean;
+  vendorsDone: boolean;
+  itemsDone: boolean;
+  currenciesDone: boolean;
 }
 
 function ConfigMenuPage({
@@ -45,6 +49,10 @@ function ConfigMenuPage({
   glInProgress,
   srDone,
   srInProgress,
+  customersDone,
+  vendorsDone,
+  itemsDone,
+  currenciesDone,
 }: Props) {
   return (
     <div>
@@ -119,46 +127,50 @@ function ConfigMenuPage({
         <h3>{strings.masterData}</h3>
         <div className="menu-grid">
           <div
-            className="menu-box"
+            className={`menu-box ${customersDone ? 'done' : ''}`}
             onClick={goToCustomers}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter' || e.key === ' ') goToCustomers();
             }}
           >
+            {customersDone && <div className="checkmark">✔</div>}
             <UserIcon />
             <div>{strings.customers}</div>
           </div>
           <div
-            className="menu-box"
+            className={`menu-box ${vendorsDone ? 'done' : ''}`}
             onClick={goToVendors}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter' || e.key === ' ') goToVendors();
             }}
           >
+            {vendorsDone && <div className="checkmark">✔</div>}
             <FactoryIcon />
             <div>{strings.vendors}</div>
           </div>
           <div
-            className="menu-box"
+            className={`menu-box ${itemsDone ? 'done' : ''}`}
             onClick={goToItems}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter' || e.key === ' ') goToItems();
             }}
           >
+            {itemsDone && <div className="checkmark">✔</div>}
             <CubeIcon />
             <div>{strings.items}</div>
           </div>
           <div
-            className="menu-box"
+            className={`menu-box ${currenciesDone ? 'done' : ''}`}
             onClick={goToCurrencies}
             tabIndex={0}
             onKeyDown={e => {
               if (e.key === 'Enter' || e.key === ' ') goToCurrencies();
             }}
           >
+            {currenciesDone && <div className="checkmark">✔</div>}
             <MoneyIcon />
             <div>{strings.currencies}</div>
           </div>

--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -17,6 +17,11 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug }: Pr
   const [fields, setFields] = useState<TableField[]>([]);
   const [rowData, setRowData] = useState<Record<string, string>[]>(rows);
   const gridRef = useRef<AgGridReact<Record<string, string>>>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  function openFileDialog() {
+    fileInputRef.current?.click();
+  }
 
   useEffect(() => {
     getTableFields('Currency').then(setFields);
@@ -163,11 +168,23 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug }: Pr
           Download template
         </a>
       </p>
-      <input type="file" accept=".xlsx,.csv" onChange={handleFileUpload} />
+      <input
+        type="file"
+        accept=".xlsx,.csv"
+        onChange={handleFileUpload}
+        ref={fileInputRef}
+        style={{ display: 'none' }}
+      />
+      <button type="button" className="next-btn" onClick={openFileDialog}>
+        Upload
+      </button>
+      <div className="divider" />
       <div className="nav">
-        <button className="back-btn" onClick={back}>{strings.back}</button>
-        <button className="next-btn" onClick={next}>{strings.next}</button>
-        <button className="skip-btn" onClick={next}>{strings.skip}</button>
+        <button className="skip-btn" onClick={back}>{strings.back}</button>
+        <button className="next-btn" onClick={next}>Confirm</button>
+        <button className="skip-btn skip-right" onClick={next}>
+          {strings.skip}
+        </button>
       </div>
     </div>
   );

--- a/style.css
+++ b/style.css
@@ -38,6 +38,9 @@ label {
 .nav .skip-btn {
   margin-left: 10px;
 }
+.nav .skip-right {
+  margin-left: auto;
+}
 .nav.final .next-btn {
   margin-left: auto;
 }
@@ -718,6 +721,11 @@ h3 {
 
 .skip-section-btn:hover {
   background-color: rgba(0, 128, 128, 0.1);
+}
+
+.divider {
+  border-top: 1px solid #d0d0d0;
+  margin: 20px 0;
 }
 
 /* Field wizard layout */


### PR DESCRIPTION
## Summary
- tweak navigation after confirming Master Data pages
- allow Config menu to show completion for Master Data pages
- update currency page UI with an upload button, new divider, and aligned skip link
- style updates for new skip-right and divider helpers

## Testing
- `npm run build` *(fails: vite not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a4e2a88ac8322aed9599c6d44337d