### PR TITLE
Update currency grid toolbar and upload controls

### DIFF
--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -221,39 +221,48 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
     <div>
       <div className="section-header">{strings.currencies}</div>
       <p>You can add, edit, or delete currencies directly below:</p>
-      <div className="ag-theme-alpine" style={{ height: 400, width: '100%' }}>
+      <div className="grid-toolbar">
+        <button type="button" onClick={addRow}>Add Row</button>
+        <button type="button" onClick={deleteSelected}>Delete Selected</button>
+        <button type="button" className="ai-btn" onClick={askAIForGrid}>
+          <span className="icon">✨</span> Ask AI to Help
+        </button>
+      </div>
+      <div className="ag-theme-alpine currency-grid" style={{ height: 400, width: '100%' }}>
         <AgGridReact
           ref={gridRef}
           rowData={rowData}
           columnDefs={columnDefs}
           rowSelection="multiple"
+          rowHeight={36}
           onCellValueChanged={onCellValueChanged}
           defaultColDef={{ flex: 1, resizable: true, editable: true }}
         />
       </div>
-      <div className="nav" style={{ marginTop: 10 }}>
-        <button type="button" onClick={addRow}>Add Row</button>
-        <button type="button" onClick={deleteSelected} style={{ marginLeft: 10 }}>Delete Selected</button>
-        <button type="button" className="ai-btn" onClick={askAIForGrid} style={{ marginLeft: 10 }}>
-          <span className="icon">✨</span> Ask AI to Help
-        </button>
-      </div>
       <p style={{ marginTop: 20 }}>
-        Alternatively, you can upload a file with a list of currencies.{' '}
-        <a href="#" onClick={e => { e.preventDefault(); downloadTemplate(); }}>
+        <input
+          type="file"
+          accept=".xlsx,.csv"
+          onChange={handleFileUpload}
+          ref={fileInputRef}
+          style={{ display: 'none' }}
+        />
+        <button
+          type="button"
+          className="next-btn"
+          onClick={openFileDialog}
+          style={{ marginRight: 10 }}
+        >
+          Upload CSV/XSLX
+        </button>
+        <button
+          type="button"
+          className="download-template-btn"
+          onClick={downloadTemplate}
+        >
           Download template
-        </a>
+        </button>
       </p>
-      <input
-        type="file"
-        accept=".xlsx,.csv"
-        onChange={handleFileUpload}
-        ref={fileInputRef}
-        style={{ display: 'none' }}
-      />
-      <button type="button" className="next-btn" onClick={openFileDialog}>
-        Upload
-      </button>
       <div className="divider" />
       <div className="nav">
         <button className="skip-btn" onClick={back}>{strings.back}</button>

--- a/style.css
+++ b/style.css
@@ -901,3 +901,36 @@ h3 {
   font-weight: normal;
   color: #555;
 }
+
+/* Grid toolbar above ag-grid */
+.grid-toolbar {
+  margin-bottom: 6px;
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+/* Currency grid theme tweaks */
+.currency-grid {
+  --ag-header-background-color: var(--bc-gray);
+  --ag-header-foreground-color: var(--bc-text);
+  --ag-row-hover-color: var(--bc-gray);
+  --ag-odd-row-background-color: #fafafa;
+  --ag-border-color: #e1dfdd;
+  --ag-row-height: 36px;
+  --ag-header-height: 38px;
+  --ag-grid-size: 6px;
+}
+
+.download-template-btn {
+  background: transparent;
+  border: 1px solid var(--bc-blue);
+  color: var(--bc-blue);
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.download-template-btn:hover {
+  background: var(--bc-gray);
+}


### PR DESCRIPTION
## Summary
- improve currency grid styling
- add toolbar above grid with row management buttons
- update upload section with CSV/XSLX wording and download button
- tweak global style sheet for new buttons and grid look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a55ff61b08322ae4e8805486aa434