### PR TITLE
Add Suggest Again AI modal support on currency page

### DIFF
--- a/src/components/AISuggestionModal.tsx
+++ b/src/components/AISuggestionModal.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { AgGridReact } from 'ag-grid-react';
+
+interface Props {
+  show: boolean;
+  rows: Record<string, string>[];
+  columnDefs: any[];
+  explanation: string;
+  loading: boolean;
+  onAccept: () => void;
+  onClose: () => void;
+  onSuggestAgain: (extra: string) => void;
+}
+
+export default function AISuggestionModal({
+  show,
+  rows,
+  columnDefs,
+  explanation,
+  loading,
+  onAccept,
+  onClose,
+  onSuggestAgain,
+}: Props) {
+  const [extra, setExtra] = useState('');
+
+  if (!show) return null;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <div className="ag-theme-alpine" style={{ height: 300, width: '100%' }}>
+          <AgGridReact
+            rowData={rows}
+            columnDefs={columnDefs}
+            defaultColDef={{ flex: 1, resizable: true }}
+          />
+        </div>
+        <p style={{ whiteSpace: 'pre-wrap', marginTop: 10 }}>
+          {loading ? 'Loading...' : explanation}
+        </p>
+        <label htmlFor="ai-extra" className="ai-extra-label">
+          Additional Instructions
+        </label>
+        <textarea
+          id="ai-extra"
+          value={extra}
+          onChange={e => setExtra(e.target.value)}
+          rows={6}
+        />
+        <button className="go-btn" onClick={() => onSuggestAgain(extra)}>
+          Suggest again
+        </button>
+        <div className="nav modal-actions">
+          <button className="next-btn" onClick={onAccept} disabled={loading}>
+            Accept
+          </button>
+          <button className="next-btn" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -5,6 +5,7 @@ import 'ag-grid-community/styles/ag-theme-alpine.css';
 import strings from '../../res/strings';
 import { getTableFields, TableField } from '../utils/schema';
 import { askOpenAI } from '../utils/ai';
+import AISuggestionModal from '../components/AISuggestionModal';
 
 interface Props {
   rows: Record<string, string>[];
@@ -98,7 +99,7 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
     setRows(updated);
   }
 
-  async function askAIForGrid() {
+  async function askAIForGrid(extra: string = '') {
     try {
       setShowAI(true);
       setAiLoading(true);
@@ -108,7 +109,8 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         '\nCurrent currency rows:\n' +
         JSON.stringify(rowData, null, 2) +
         '\nSuggest the best rows for the currency table. ' +
-        'Return JSON with a "rows" array and an "explanation" string.';
+        'Return JSON with a "rows" array and an "explanation" string.' +
+        (extra ? `\nAdditional Instructions:\n${extra}` : '');
       const ans = await askOpenAI(prompt, logDebug);
       const cleaned = ans.replace(/```json|```/g, '').trim();
       const parsed = JSON.parse(cleaned);
@@ -127,6 +129,10 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
     setRowData(aiRows);
     setRows(aiRows);
     setShowAI(false);
+  }
+
+  function suggestAgain(extra: string) {
+    askAIForGrid(extra);
   }
 
   function onCellValueChanged(params: any) {
@@ -262,22 +268,16 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
           {strings.skip}
         </button>
       </div>
-      {showAI && (
-        <div className="modal-overlay" onClick={() => setShowAI(false)}>
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <div className="ag-theme-alpine" style={{ height: 300, width: '100%' }}>
-              <AgGridReact rowData={aiRows} columnDefs={columnDefs} defaultColDef={{ flex: 1, resizable: true }} />
-            </div>
-            <p style={{ whiteSpace: 'pre-wrap', marginTop: 10 }}>
-              {aiLoading ? 'Loading...' : aiExplanation}
-            </p>
-            <div className="nav modal-actions">
-              <button className="next-btn" onClick={acceptAI} disabled={aiLoading}>Accept</button>
-              <button className="next-btn" onClick={() => setShowAI(false)}>Cancel</button>
-            </div>
-          </div>
-        </div>
-      )}
+      <AISuggestionModal
+        show={showAI}
+        rows={aiRows}
+        columnDefs={columnDefs}
+        explanation={aiExplanation}
+        loading={aiLoading}
+        onAccept={acceptAI}
+        onClose={() => setShowAI(false)}
+        onSuggestAgain={suggestAgain}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable `AISuggestionModal` component for AI grid suggestions
- update currency page to use `AISuggestionModal`
- allow passing extra instructions for additional AI suggestions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5727e9a08322bb1b797f124eb293