### PR TITLE
Improve grid interactions and download button UX

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -109,3 +109,17 @@ export function SparkleIcon(props: React.SVGProps<SVGSVGElement>) {
   );
 }
 
+export function ExcelIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      className={props.className ? props.className + ' excel-icon' : 'excel-icon'}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="16" rx="2" fill="#107C41" />
+      <path d="M10 9l2 3-2 3m4-6l-2 3 2 3" stroke="#fff" strokeWidth="2" fill="none" />
+    </svg>
+  );
+}
+

--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -5,6 +5,7 @@ import 'ag-grid-community/styles/ag-theme-alpine.css';
 import strings from '../../res/strings';
 import { getTableFields, TableField } from '../utils/schema';
 import { askOpenAI } from '../utils/ai';
+import { ExcelIcon } from '../components/Icons';
 
 interface Props {
   rows: Record<string, string>[];
@@ -108,12 +109,12 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         '\nCurrent currency rows:\n' +
         JSON.stringify(rowData, null, 2) +
         '\nSuggest the best rows for the currency table. ' +
-        'Return JSON with a "rows" array and an "explanation" string.';
+        'Return JSON with a "rows" array and an "explanation" string no longer than 500 characters.';
       const ans = await askOpenAI(prompt, logDebug);
       const cleaned = ans.replace(/```json|```/g, '').trim();
       const parsed = JSON.parse(cleaned);
       setAiRows(filterRows(parsed.rows || []));
-      setAiExplanation(parsed.explanation || '');
+      setAiExplanation((parsed.explanation || '').slice(0, 500));
     } catch (e) {
       console.error(e);
       setAiRows([]);
@@ -237,8 +238,10 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
           rowHeight={36}
           onCellValueChanged={onCellValueChanged}
           defaultColDef={{ flex: 1, resizable: true, editable: true }}
+          singleClickEdit={true}
         />
       </div>
+      <div className="add-row-icon" onClick={addRow}>+</div>
       <p style={{ marginTop: 20 }}>
         <input
           type="file"
@@ -249,7 +252,7 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         />
         <button
           type="button"
-          className="next-btn"
+          className="download-template-btn"
           onClick={openFileDialog}
           style={{ marginRight: 10 }}
         >
@@ -257,10 +260,11 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         </button>
         <button
           type="button"
-          className="download-template-btn"
+          className="download-link"
           onClick={downloadTemplate}
         >
-          Download template
+          <ExcelIcon />
+          Download Template
         </button>
       </p>
       <div className="divider" />
@@ -275,7 +279,12 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         <div className="modal-overlay" onClick={() => setShowAI(false)}>
           <div className="modal" onClick={e => e.stopPropagation()}>
             <div className="ag-theme-alpine" style={{ height: 300, width: '100%' }}>
-              <AgGridReact rowData={aiRows} columnDefs={columnDefs} defaultColDef={{ flex: 1, resizable: true }} />
+              <AgGridReact
+                rowData={aiRows}
+                columnDefs={columnDefs}
+                defaultColDef={{ flex: 1, resizable: true }}
+                singleClickEdit={true}
+              />
             </div>
             <p style={{ whiteSpace: 'pre-wrap', marginTop: 10 }}>
               {aiLoading ? 'Loading...' : aiExplanation}

--- a/src/pages/VendorsPage.tsx
+++ b/src/pages/VendorsPage.tsx
@@ -31,7 +31,12 @@ export default function VendorsPage({ rows, next, back }: Props) {
     <div>
       <div className="section-header">{strings.vendors}</div>
       <div className="ag-theme-alpine" style={{ height: 400, width: '100%' }}>
-        <AgGridReact rowData={rows} columnDefs={columnDefs} defaultColDef={{ flex: 1, resizable: true }} />
+        <AgGridReact
+          rowData={rows}
+          columnDefs={columnDefs}
+          defaultColDef={{ flex: 1, resizable: true }}
+          singleClickEdit={true}
+        />
       </div>
       <div className="nav">
         <button className="back-btn" onClick={back}>{strings.back}</button>

--- a/style.css
+++ b/style.css
@@ -934,3 +934,35 @@ h3 {
 .download-template-btn:hover {
   background: var(--bc-gray);
 }
+
+/* Center text vertically in ag-grid rows */
+.ag-theme-alpine .ag-cell {
+  display: flex;
+  align-items: center;
+}
+
+/* Simple plus icon below grid */
+.add-row-icon {
+  color: var(--bc-blue);
+  cursor: pointer;
+  font-size: 1.5em;
+  text-align: center;
+  margin-top: 4px;
+}
+
+/* Download template link style */
+.download-link {
+  background: none;
+  border: none;
+  color: var(--bc-blue);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  font-size: 1em;
+}
+
+.download-link .excel-icon {
+  width: 16px;
+  height: 16px;
+}


### PR DESCRIPTION
## Summary
- center ag-grid cell content
- add Excel icon and text link styles
- show text input on single click in grids
- add `+` icon under currency table to insert rows
- limit AI explanation to 500 chars and show Excel icon on download link

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a58d492f4832297ad18c8cdb36319