### PR TITLE
Improve popup grid loading state

### DIFF
--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -275,7 +275,15 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         <div className="modal-overlay" onClick={() => setShowAI(false)}>
           <div className="modal" onClick={e => e.stopPropagation()}>
             <div className="ag-theme-alpine" style={{ height: 300, width: '100%' }}>
-              <AgGridReact rowData={aiRows} columnDefs={columnDefs} defaultColDef={{ flex: 1, resizable: true }} />
+              {aiLoading && aiRows.length === 0 ? (
+                <div style={{ padding: 10, textAlign: 'center' }}>...</div>
+              ) : (
+                <AgGridReact
+                  rowData={aiRows}
+                  columnDefs={columnDefs}
+                  defaultColDef={{ flex: 1, resizable: true }}
+                />
+              )}
             </div>
             <p style={{ whiteSpace: 'pre-wrap', marginTop: 10 }}>
               {aiLoading ? 'Loading...' : aiExplanation}

--- a/style.css
+++ b/style.css
@@ -373,7 +373,7 @@ h3 {
   border-radius: 4px;
   width: 90%;
   max-width: 600px;
-  min-width: 300px;
+  min-width: 400px;
 }
 
 .modal textarea {


### PR DESCRIPTION
## Summary
- show placeholder `...` in AI suggestion popup grid while loading
- increase popup minimum width to 400px

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a596432588322a1916acf2b428701