### PR TITLE
Improve AI response parsing

### DIFF
--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -4,7 +4,7 @@ import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 import strings from '../../res/strings';
 import { getTableFields, TableField } from '../utils/schema';
-import { askOpenAI } from '../utils/ai';
+import { askOpenAI, parseJSONFromText } from '../utils/ai';
 
 interface Props {
   rows: Record<string, string>[];
@@ -110,8 +110,7 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         '\nSuggest the best rows for the currency table. ' +
         'Return JSON with a "rows" array and an "explanation" string.';
       const ans = await askOpenAI(prompt, logDebug);
-      const cleaned = ans.replace(/```json|```/g, '').trim();
-      const parsed = JSON.parse(cleaned);
+      const parsed = parseJSONFromText(ans) || {};
       setAiRows(filterRows(parsed.rows || []));
       setAiExplanation(parsed.explanation || '');
     } catch (e) {

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -56,3 +56,26 @@ export function parseAISuggestion(text: string): AISuggestion {
     return { suggested: text, confidence: '', reasoning: '' };
   }
 }
+
+/**
+ * Try to parse JSON that may be embedded inside arbitrary text.
+ * Returns the parsed object or null if no JSON could be extracted.
+ */
+export function parseJSONFromText(text: string): any | null {
+  if (!text) return null;
+  // First look for a ```json code block
+  const block = text.match(/```json\s*([\s\S]*?)\s*```/i);
+  let cleaned = block ? block[1].trim() : text.trim();
+  // If there's additional text before or after the JSON, slice from the first
+  // opening brace to the last closing brace.
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  if (start !== -1 && end !== -1) {
+    cleaned = cleaned.slice(start, end + 1);
+  }
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- make AI utilities robust to text surrounding JSON
- use new parser in Currency page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a599a11048322bb1d37a40e96ea2e