### PR TITLE
Improve AI grid parsing

### DIFF
--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -4,7 +4,7 @@ import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 import strings from '../../res/strings';
 import { getTableFields, TableField } from '../utils/schema';
-import { askOpenAI } from '../utils/ai';
+import { askOpenAI, parseAIGrid } from '../utils/ai';
 import AISuggestionModal from '../components/AISuggestionModal';
 
 interface Props {
@@ -112,10 +112,9 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         'Return JSON with a "rows" array and an "explanation" string.' +
         (extra ? `\nAdditional Instructions:\n${extra}` : '');
       const ans = await askOpenAI(prompt, logDebug);
-      const cleaned = ans.replace(/```json|```/g, '').trim();
-      const parsed = JSON.parse(cleaned);
-      setAiRows(filterRows(parsed.rows || []));
-      setAiExplanation(parsed.explanation || '');
+      const parsed = parseAIGrid(ans);
+      setAiRows(filterRows(parsed.rows));
+      setAiExplanation(parsed.explanation);
     } catch (e) {
       console.error(e);
       setAiRows([]);


### PR DESCRIPTION
## Summary
- handle extraneous text in AI responses with new `parseAIGrid`
- use the helper on the Currency page

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5b8471c88322b2c8a61f72431f53