### PR TITLE
Improve grid UI and AI prompt

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -174,7 +174,8 @@ function App() {
       'Confidence must be one of "Very High", "High", "Medium", "Low", or "Very Low". ' +
       (options && options.length
         ? 'Choose a value only from the provided options.'
-        : '');
+        : '') +
+      ' The "Reasoning" text must be no more than 500 characters.';
     return prompt;
   }
 

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -109,3 +109,18 @@ export function SparkleIcon(props: React.SVGProps<SVGSVGElement>) {
   );
 }
 
+
+export function ExcelIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      className={props.className ? props.className + ' menu-svg-icon' : 'menu-svg-icon'}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" stroke="currentColor" strokeWidth="2" fill="none" />
+      <path d="M8 8l8 8M16 8l-8 8" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  );
+}

--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -6,6 +6,7 @@ import strings from '../../res/strings';
 import { getTableFields, TableField } from '../utils/schema';
 import { askOpenAI } from '../utils/ai';
 import AISuggestionModal from '../components/AISuggestionModal';
+import { ExcelIcon } from '../components/Icons';
 
 interface Props {
   rows: Record<string, string>[];
@@ -109,7 +110,7 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         '\nCurrent currency rows:\n' +
         JSON.stringify(rowData, null, 2) +
         '\nSuggest the best rows for the currency table. ' +
-        'Return JSON with a "rows" array and an "explanation" string.' +
+        'Return JSON with a "rows" array and an "explanation" string no longer than 500 characters.' +
         (extra ? `\nAdditional Instructions:\n${extra}` : '');
       const ans = await askOpenAI(prompt, logDebug);
       const cleaned = ans.replace(/```json|```/g, '').trim();
@@ -241,10 +242,19 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
           columnDefs={columnDefs}
           rowSelection="multiple"
           rowHeight={36}
+          singleClickEdit={true}
+          onCellFocused={e => {
+            if (e.rowIndex == null || !e.column) return;
+            gridRef.current?.api.startEditingCell({
+              rowIndex: e.rowIndex,
+              colKey: e.column.getColId(),
+            });
+          }}
           onCellValueChanged={onCellValueChanged}
           defaultColDef={{ flex: 1, resizable: true, editable: true }}
         />
       </div>
+      <div className="grid-add-row" onClick={addRow}>+</div>
       <p style={{ marginTop: 20 }}>
         <input
           type="file"
@@ -255,7 +265,7 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         />
         <button
           type="button"
-          className="next-btn"
+          className="download-template-btn"
           onClick={openFileDialog}
           style={{ marginRight: 10 }}
         >
@@ -263,10 +273,10 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         </button>
         <button
           type="button"
-          className="download-template-btn"
+          className="download-template-link"
           onClick={downloadTemplate}
         >
-          Download template
+          <ExcelIcon className="excel-icon" /> Download Template
         </button>
       </p>
       <div className="divider" />

--- a/style.css
+++ b/style.css
@@ -934,3 +934,39 @@ h3 {
 .download-template-btn:hover {
   background: var(--bc-gray);
 }
+.ag-theme-alpine .ag-cell {
+  display: flex;
+  align-items: center;
+}
+
+.grid-add-row {
+  margin-top: 6px;
+  text-align: center;
+  cursor: pointer;
+  color: var(--bc-blue);
+  font-size: 1.5em;
+}
+
+.grid-add-row:hover {
+  color: var(--bc-blue-dark);
+}
+
+.excel-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+}
+
+.download-template-link {
+  background: none;
+  border: none;
+  color: var(--bc-blue);
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
+.download-template-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- update AI prompt instructions to limit reasoning to 500 characters
- show plus icon to add new row in currency grid
- center currency grid text and enable single-click editing
- restyle upload and download actions and add Excel icon
- add ExcelIcon component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5b54f19c8322894b1a307b2a67cf