### PR TITLE
Fix AI modal loading message placement

### DIFF
--- a/src/components/AISuggestionModal.tsx
+++ b/src/components/AISuggestionModal.tsx
@@ -34,12 +34,10 @@ export default function AISuggestionModal({
             rowData={rows}
             columnDefs={columnDefs}
             defaultColDef={{ flex: 1, resizable: true }}
-            overlayNoRowsTemplate={loading ? '...' : 'No rows'}
+            overlayNoRowsTemplate={loading ? 'Loading...' : 'No rows'}
           />
         </div>
-        <p style={{ whiteSpace: 'pre-wrap', marginTop: 10 }}>
-          {loading ? 'Loading...' : explanation}
-        </p>
+        <p style={{ whiteSpace: 'pre-wrap', marginTop: 10 }}>{explanation}</p>
         <label htmlFor="ai-extra" className="ai-extra-label">
           Additional Instructions
         </label>


### PR DESCRIPTION
## Summary
- display "Loading..." in ag-grid overlay instead of below the grid
- show explanation text only in the modal body

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5dd2aa6883228a0b4078f9cb657a