### PR TITLE
Align upload buttons

### DIFF
--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -254,7 +254,7 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         />
       </div>
       <div className="grid-add-row" onClick={addRow}>+</div>
-      <p style={{ marginTop: 20 }}>
+      <div className="file-controls">
         <input
           type="file"
           accept=".xlsx,.csv"
@@ -266,7 +266,6 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
           type="button"
           className="download-template-btn"
           onClick={openFileDialog}
-          style={{ marginRight: 10 }}
         >
           Upload CSV/XSLX
         </button>
@@ -277,7 +276,7 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
         >
           <ExcelIcon className="excel-icon" /> Download Template
         </button>
-      </p>
+      </div>
       <div className="divider" />
       <div className="nav">
         <button className="skip-btn" onClick={back}>{strings.back}</button>

--- a/style.css
+++ b/style.css
@@ -951,6 +951,14 @@ h3 {
   color: var(--bc-blue-dark);
 }
 
+.file-controls {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
+
 .excel-icon {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
## Summary
- center the download template button with the upload button
- add a small flex container for the upload/download controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5d9681f083228eeb27ae6d5b5e7c