### PR TITLE
Replace ExcelIcon with image

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ExcelImg from '../images/Microsoft_Office_Excel_(2019–present).svg.png';
 
 export function InfoIcon() {
   return (
@@ -110,17 +111,14 @@ export function SparkleIcon(props: React.SVGProps<SVGSVGElement>) {
 }
 
 
-export function ExcelIcon(props: React.SVGProps<SVGSVGElement>) {
+export function ExcelIcon(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+  const { className, alt, ...rest } = props;
   return (
-    <svg
-      {...props}
-      className={props.className ? props.className + ' menu-svg-icon' : 'menu-svg-icon'}
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden="true"
-    >
-      <rect x="3" y="3" width="18" height="18" rx="2" stroke="currentColor" strokeWidth="2" fill="none" />
-      <path d="M8 8l8 8M16 8l-8 8" stroke="currentColor" strokeWidth="2" />
-    </svg>
+    <img
+      {...rest}
+      src={ExcelImg}
+      alt={alt ?? 'Excel'}
+      className={className ? className + ' menu-svg-icon' : 'menu-svg-icon'}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- use `Microsoft_Office_Excel_(2019–present).svg.png` to render Excel icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a5f69b1608322b48df4e078ec7199