### PR TITLE
Add confirm toggle to currency page

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1080,6 +1080,8 @@ function App() {
               back={back}
               logDebug={logDebug}
               formData={formData}
+              confirmed={currenciesDone}
+              setConfirmed={setCurrenciesDone}
             />
           )}
           {step === 10 && (

--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -15,9 +15,20 @@ interface Props {
   back: () => void;
   logDebug?: (msg: string) => void;
   formData: { [key: string]: any };
+  confirmed: boolean;
+  setConfirmed: (val: boolean) => void;
 }
 
-export default function CurrencyPage({ rows, setRows, next, back, logDebug, formData }: Props) {
+export default function CurrencyPage({
+  rows,
+  setRows,
+  next,
+  back,
+  logDebug,
+  formData,
+  confirmed,
+  setConfirmed,
+}: Props) {
   const [fields, setFields] = useState<TableField[]>([]);
   const [rowData, setRowData] = useState<Record<string, string>[]>([]);
   const [showAI, setShowAI] = useState(false);
@@ -226,9 +237,18 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
     URL.revokeObjectURL(url);
   }
 
+  function handleConfirm() {
+    if (confirmed) {
+      setConfirmed(false);
+    } else {
+      next();
+    }
+  }
+
   return (
     <div>
       <div className="section-header">{strings.currencies}</div>
+      {confirmed && <div className="confirmed-banner">Confirmed!</div>}
       <p>You can add, edit, or delete currencies directly below:</p>
       <div className="grid-toolbar">
         <button type="button" onClick={addRow}>Add Row</button>
@@ -287,10 +307,14 @@ export default function CurrencyPage({ rows, setRows, next, back, logDebug, form
       <div className="divider" />
       <div className="nav">
         <button className="skip-btn" onClick={back}>{strings.back}</button>
-        <button className="next-btn" onClick={next}>Confirm</button>
-        <button className="skip-btn skip-right" onClick={next}>
-          {strings.skip}
+        <button className="next-btn" onClick={handleConfirm}>
+          {confirmed ? 'Mark as Not Confirmed' : 'Confirm'}
         </button>
+        {!confirmed && (
+          <button className="skip-btn skip-right" onClick={next}>
+            {strings.skip}
+          </button>
+        )}
       </div>
       <AISuggestionModal
         show={showAI}


### PR DESCRIPTION
## Summary
- allow toggling confirmation status on Currency page
- surface confirmation state with `Confirmed!` banner
- pass status from App so currencies can be marked unconfirmed

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a621955d08322ae764318cfa9704f