### PR TITLE
Remove hover from download link

### DIFF
--- a/style.css
+++ b/style.css
@@ -994,6 +994,4 @@ h3 {
   align-items: center;
 }
 
-.download-template-link:hover {
-  text-decoration: underline;
-}
+


### PR DESCRIPTION
## Summary
- remove `:hover` style from `Download Template` link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a6667040083228602f52ce313f0c1