### PR TITLE
Enable keyboard focus for grids

### DIFF
--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -204,7 +204,15 @@ export default function CurrencyPage({
           <span className="icon">✨</span> Ask AI to Help
         </button>
       </div>
-      <div className="ag-theme-alpine currency-grid" style={{ height: 400, width: '100%' }}>
+      <div
+        className="ag-theme-alpine currency-grid"
+        style={{ height: 400, width: '100%' }}
+        tabIndex={0}
+        onFocus={() => {
+          if (!gridRef.current || !columnDefs.length) return;
+          gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+        }}
+      >
         <AgGridReact
           ref={gridRef}
           rowData={rowData}

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -204,7 +204,15 @@ export default function CustomersPage({
           <span className="icon">✨</span> Ask AI to Help
         </button>
       </div>
-      <div className="ag-theme-alpine customer-grid" style={{ height: 400, width: '100%' }}>
+      <div
+        className="ag-theme-alpine customer-grid"
+        style={{ height: 400, width: '100%' }}
+        tabIndex={0}
+        onFocus={() => {
+          if (!gridRef.current || !columnDefs.length) return;
+          gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+        }}
+      >
         <AgGridReact
           ref={gridRef}
           rowData={rowData}

--- a/src/pages/VendorsPage.tsx
+++ b/src/pages/VendorsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useRef } from 'react';
 import { AgGridReact } from 'ag-grid-react';
 import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
@@ -13,6 +13,7 @@ interface Props {
 
 export default function VendorsPage({ rows, next, back }: Props) {
   const [fields, setFields] = useState<TableField[]>([]);
+  const gridRef = useRef<AgGridReact<Record<string, string>>>(null);
 
   useEffect(() => {
     getTableFields('Vendor').then(setFields);
@@ -30,8 +31,21 @@ export default function VendorsPage({ rows, next, back }: Props) {
   return (
     <div>
       <div className="section-header">{strings.vendors}</div>
-      <div className="ag-theme-alpine" style={{ height: 400, width: '100%' }}>
-        <AgGridReact rowData={rows} columnDefs={columnDefs} defaultColDef={{ flex: 1, resizable: true }} />
+      <div
+        className="ag-theme-alpine"
+        style={{ height: 400, width: '100%' }}
+        tabIndex={0}
+        onFocus={() => {
+          if (!gridRef.current || !columnDefs.length) return;
+          gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+        }}
+      >
+        <AgGridReact
+          ref={gridRef}
+          rowData={rows}
+          columnDefs={columnDefs}
+          defaultColDef={{ flex: 1, resizable: true }}
+        />
       </div>
       <div className="nav">
         <button className="back-btn" onClick={back}>{strings.back}</button>


### PR DESCRIPTION
## Summary
- allow the AG Grid containers to receive focus
- focus the first grid cell when the grid gains focus

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a6d3569808322a367f4d9b66bc27e