### PR TITLE
Filter common fields

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -255,7 +255,7 @@ function App() {
         });
         setVendorRows(vsimple);
 
-        const customerFields = await getTableFields('Customer');
+        const customerFields = await getTableFields('Customer', true);
         const customerNames = customerFields.map(f => f.xmlName);
         const custRows = findTableRows(data, 18) || [];
         logDebug(`Customer: read ${custRows.length} rows from NAV27.0.US.ENU.STANDARD.xml`);
@@ -279,7 +279,7 @@ function App() {
         logDebug(`Customer: prepared ${custSimple.length} rows for grid`);
         setCustomerRows(custSimple);
 
-        const currencyFields = await getTableFields('Currency');
+        const currencyFields = await getTableFields('Currency', true);
         const currencyNames = currencyFields.map(f => f.xmlName);
         const rows = findTableRows(data, 4) || [];
         logDebug(`Currency: read ${rows.length} rows from NAV27.0.US.ENU.STANDARD.xml`);

--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -50,7 +50,7 @@ export default function CurrencyPage({
   }
 
   useEffect(() => {
-    getTableFields('Currency').then(setFields);
+    getTableFields('Currency', true).then(setFields);
   }, []);
 
   useEffect(() => {

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -50,7 +50,7 @@ export default function CustomersPage({
   }
 
   useEffect(() => {
-    getTableFields('Customer').then(setFields);
+    getTableFields('Customer', true).then(setFields);
   }, []);
 
   useEffect(() => {

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -5,7 +5,7 @@ let mappings: any = null;
 
 async function loadSchema() {
   if (!cache) {
-    const resp = await fetch('/BC_Master_Tables_and_Fields_Complete.json');
+    const resp = await fetch('/BC_Master_Tables_and_Fields_Complete_updated.json');
     cache = await resp.json();
   }
   return cache;
@@ -28,16 +28,24 @@ export interface TableField {
   xmlName: string;
 }
 
-export async function getTableFields(tableName: string): Promise<TableField[]> {
+export async function getTableFields(
+  tableName: string,
+  commonOnly: boolean = false,
+): Promise<TableField[]> {
   const [schema, map] = await Promise.all([loadSchema(), loadMappings()]);
   if (Array.isArray(schema)) {
     const table = schema.find((t: any) => t.Name === tableName);
     if (table && Array.isArray(table.Fields)) {
-      return table.Fields.map((f: any) => {
-        const name = String(f['BC Field Name'] || f.Field);
-        const xmlName = map[name] || mapFieldName(name);
-        return { name, xmlName };
-      });
+      return table.Fields
+        .filter(
+          (f: any) =>
+            !commonOnly || String(f.common || '').toLowerCase() === 'yes',
+        )
+        .map((f: any) => {
+          const name = String(f['BC Field Name'] || f.Field);
+          const xmlName = map[name] || mapFieldName(name);
+          return { name, xmlName };
+        });
     }
   }
   return [];


### PR DESCRIPTION
## Summary
- use updated BC Master Tables schema
- filter Customer and Currency columns to common fields

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a6ebebe98832299ef5a7478ef1640