### PR TITLE
Add Purchases & Payables setup page

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -15,6 +15,7 @@ export default {
   companyInfo: 'Company Information',
   generalLedgerSetup: 'General Ledger Setup',
   salesReceivablesSetup: 'Sales & Receivables Setup',
+  purchasePayablesSetup: 'Purchases & Payables Setup',
   common: 'Common',
   sometimes: 'Sometimes',
   additional: 'Additional',

--- a/src/fieldNames.ts
+++ b/src/fieldNames.ts
@@ -81,6 +81,22 @@ export const srFieldNames = [
   'Copy Comments Blanket Order to Order',
 ];
 
+export const ppFieldNames = [
+  'Receipt on Invoice',
+  'Ext. Doc. No. Mandatory (Purchases)',
+  'Vendor Nos.',
+  'Quote Nos. (Purchases)',
+  'Order Nos. (Purchases)',
+  'Invoice Nos. (Purchases)',
+  'Posted Invoice Nos. (Purchases)',
+  'Credit Memo Nos. (Purchases)',
+  'Posted Credit Memo Nos. (Purchases)',
+  'Posted Receipt Nos.',
+  'Blanket Order Nos. (Purchases)',
+  'Return Order Nos. (Purchases)',
+  'Posted Return Shpt. Nos.',
+];
+
 /**
  * Convert a list of names into basic CompanyField objects.
  */

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -5,6 +5,7 @@ import {
   CompanyIcon,
   BookIcon,
   CartIcon,
+  BoxIcon,
   UserIcon,
   FactoryIcon,
   CubeIcon,
@@ -16,6 +17,7 @@ interface Props {
   goToCompanyInfo: () => void;
   goToGLSetup: () => void;
   goToSRSetup: () => void;
+  goToPPSetup: () => void;
   goToCustomers: () => void;
   goToVendors: () => void;
   goToItems: () => void;
@@ -27,6 +29,8 @@ interface Props {
   glInProgress: boolean;
   srDone: boolean;
   srInProgress: boolean;
+  ppDone: boolean;
+  ppInProgress: boolean;
   customersDone: boolean;
   vendorsDone: boolean;
   itemsDone: boolean;
@@ -38,6 +42,7 @@ function ConfigMenuPage({
   goToCompanyInfo,
   goToGLSetup,
   goToSRSetup,
+  goToPPSetup,
   goToCustomers,
   goToVendors,
   goToItems,
@@ -49,6 +54,8 @@ function ConfigMenuPage({
   glInProgress,
   srDone,
   srInProgress,
+  ppDone,
+  ppInProgress,
   customersDone,
   vendorsDone,
   itemsDone,
@@ -120,6 +127,21 @@ function ConfigMenuPage({
             )}
             <CartIcon />
             <div>{strings.salesReceivablesSetup}</div>
+          </div>
+          <div
+            className={`menu-box ${ppDone ? 'done' : ''}`}
+            onClick={goToPPSetup}
+            tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') goToPPSetup();
+            }}
+          >
+            {ppDone && <div className="checkmark">✔</div>}
+            {!ppDone && ppInProgress && (
+              <div className="progress-dot">•</div>
+            )}
+            <BoxIcon />
+            <div>{strings.purchasePayablesSetup}</div>
           </div>
         </div>
       </div>

--- a/src/pages/PurchasePayablesPage.tsx
+++ b/src/pages/PurchasePayablesPage.tsx
@@ -1,0 +1,8 @@
+import strings from '../../res/strings';
+import WizardPage, { WizardPageProps } from './WizardPage';
+
+export default function PurchasePayablesPage(
+  props: Omit<WizardPageProps, 'title' | 'skipSection'>,
+) {
+  return <WizardPage {...props} title={strings.purchasePayablesSetup} />;
+}


### PR DESCRIPTION
## Summary
- add purchasePayablesSetup string
- list Purchase & Payables fields
- create `PurchasePayablesPage`
- extend config menu with Purchases & Payables
- wire new page and step logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a6e068aac83228f6febc1b569f914