### PR TITLE
Add Start Here overlay

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1009,6 +1009,7 @@ function App() {
               goToItems={() => setStep(8)}
               goToCurrencies={() => setStep(9)}
               back={back}
+              basicDone={basicDone}
               companyDone={companyDone}
               companyInProgress={companyInProgress}
               glDone={glDone}

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -82,6 +82,20 @@ export function CubeIcon() {
   );
 }
 
+export function ArrowDownIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      {...props}
+      className={props.className ? props.className + ' menu-svg-icon' : 'menu-svg-icon'}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 5v14M5 12l7 7 7-7" stroke="currentColor" strokeWidth="2" fill="none" />
+    </svg>
+  );
+}
+
 export function LightbulbIcon(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -9,6 +9,7 @@ import {
   FactoryIcon,
   CubeIcon,
   MoneyIcon,
+  ArrowDownIcon,
 } from '../components/Icons';
 
 interface Props {
@@ -21,6 +22,7 @@ interface Props {
   goToItems: () => void;
   goToCurrencies: () => void;
   back: () => void;
+  basicDone: boolean;
   companyDone: boolean;
   companyInProgress: boolean;
   glDone: boolean;
@@ -43,6 +45,7 @@ function ConfigMenuPage({
   goToItems,
   goToCurrencies,
   back,
+  basicDone,
   companyDone,
   companyInProgress,
   glDone,
@@ -54,6 +57,15 @@ function ConfigMenuPage({
   itemsDone,
   currenciesDone,
 }: Props) {
+  const nothingConfirmed =
+    !basicDone &&
+    !companyDone &&
+    !glDone &&
+    !srDone &&
+    !customersDone &&
+    !vendorsDone &&
+    !itemsDone &&
+    !currenciesDone;
   return (
     <div>
       <div className="section-header">{strings.selectConfigArea}</div>
@@ -61,7 +73,7 @@ function ConfigMenuPage({
         <h3>{strings.basicInfo}</h3>
         <div className="menu-grid">
           <div
-            className="menu-box"
+            className="menu-box basic-info-box"
             onClick={goToBasicInfo}
             tabIndex={0}
             onKeyDown={e => {
@@ -70,6 +82,12 @@ function ConfigMenuPage({
           >
             <InfoIcon />
             <div>{strings.basicInfoTitle}</div>
+            {nothingConfirmed && (
+              <div className="start-here-tip">
+                <span>Start Here</span>
+                <ArrowDownIcon />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -277,6 +277,42 @@ h3 {
   justify-content: center;
   font-size: 14px;
 }
+
+.basic-info-box {
+  position: relative;
+}
+
+.start-here-tip {
+  position: absolute;
+  top: -36px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bc-blue);
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  opacity: 0;
+  animation: start-here-fade 0.6s forwards;
+}
+
+.start-here-tip .menu-svg-icon {
+  width: 16px;
+  height: 16px;
+}
+
+@keyframes start-here-fade {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -10px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
 .menu-section {
   margin-bottom: 30px;
 }


### PR DESCRIPTION
## Summary
- add arrow icon component
- display 'Start Here' prompt when no sections confirmed
- style overlay above Basics box
- pass `basicDone` state to ConfigMenuPage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a70cc7e44832286c07f1ee243d60c