### PR TITLE
Fix Purchase Payables defaults and navigation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -362,6 +362,15 @@ function App() {
             }
           }
         }
+        if (val === undefined && cf.tableId) {
+          const rows = findTableRows(startData, cf.tableId) || [];
+          if (rows.length) {
+            val = rows[0][xmlName];
+            if (val && typeof val === 'object' && '#text' in val) {
+              val = val['#text'];
+            }
+          }
+        }
         if (val === undefined) {
           val = findFieldValue(startData, xmlName);
         }
@@ -927,31 +936,66 @@ function App() {
                   </li>
                   {step === 5 && (
                     <ul className="subnav">
-                      {srFields
-                        .filter(
-                          f =>
-                            f.common === 'common' ||
-                            (showSRSometimes && f.common === 'sometimes')
-                        )
-                        .map((f, i) => (
-                          <li
-                            key={f.field}
-                            className={srFieldIdx === i ? 'active' : ''}
-                            onClick={() => {
-                              setSrFieldIdx(i);
-                                setStep(5);
-                            }}
-                          >
-                            {srProgress[i] && <span className="check">✔</span>}
-                            {f.field}
-                          </li>
-                        ))}
-                    </ul>
-                  )}
+                  {srFields
+                    .filter(
+                      f =>
+                        f.common === 'common' ||
+                        (showSRSometimes && f.common === 'sometimes')
+                    )
+                    .map((f, i) => (
+                      <li
+                        key={f.field}
+                        className={srFieldIdx === i ? 'active' : ''}
+                        onClick={() => {
+                          setSrFieldIdx(i);
+                          setStep(5);
+                        }}
+                      >
+                        {srProgress[i] && <span className="check">✔</span>}
+                        {f.field}
+                      </li>
+                    ))}
                 </ul>
               )}
-            </div>
-            <div className="group">
+              <li
+                onClick={() => {
+                  setPpFieldIdx(null);
+                  setStep(6);
+                }}
+              >
+                {ppDone && <span className="check">✔</span>}
+                {!ppDone && ppInProgress && (
+                  <span className="progress-dot">•</span>
+                )}
+                {strings.purchasePayablesSetup}
+              </li>
+              {step === 6 && (
+                <ul className="subnav">
+                  {ppFields
+                    .filter(
+                      f =>
+                        f.common === 'common' ||
+                        (showPPSometimes && f.common === 'sometimes')
+                    )
+                    .map((f, i) => (
+                      <li
+                        key={f.field}
+                        className={ppFieldIdx === i ? 'active' : ''}
+                        onClick={() => {
+                          setPpFieldIdx(i);
+                          setStep(6);
+                        }}
+                      >
+                        {ppProgress[i] && <span className="check">✔</span>}
+                        {f.field}
+                      </li>
+                    ))}
+                </ul>
+              )}
+            </ul>
+          )}
+        </div>
+        <div className="group">
               <div
                 className="group-title"
                 onClick={() => setMasterOpen(!masterOpen)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface CompanyField {
   bcFieldName?: string;
   lookupTable?: number;
   lookupField?: string;
+  tableId?: number;
 }
 
 export interface BasicInfo {

--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -24,7 +24,9 @@ export async function loadConfigTables(): Promise<ConfigQuestion[]> {
   if (Array.isArray(data)) {
     data.forEach(t => {
       if (Array.isArray(t.Fields)) {
-        t.Fields.forEach((f: ConfigQuestion) => fields.push(f));
+        t.Fields.forEach((f: ConfigQuestion) =>
+          fields.push({ ...f, tableId: t.Number, tableName: t.Name })
+        );
       }
     });
   }

--- a/src/utils/jsonParsing.ts
+++ b/src/utils/jsonParsing.ts
@@ -10,6 +10,8 @@ export interface ConfigQuestion {
   'BC Field Name'?: string;
   'Lookup Table'?: number;
   'Lookup Field'?: string;
+  tableId?: number;
+  tableName?: string;
 }
 
 export function recommendedCode(text: string): string {
@@ -48,6 +50,7 @@ export function parseQuestions(
       lookupField: (q as any)?.['Lookup Field']
         ? String((q as any)['Lookup Field'])
         : undefined,
+      tableId: q?.tableId,
     };
   });
 }


### PR DESCRIPTION
## Summary
- keep table info when loading config tables
- expose `tableId` on `CompanyField`
- use tableId to read default values from NAV data
- show Purchase & Payables in the navigation

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a74e881388322957841835f3f6b09