### PR TITLE
Add lookup dropdowns for customer grid

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -78,6 +78,7 @@ function App() {
   const [debugMessages, setDebugMessages] = useState([] as string[]);
   const [countries, setCountries] = useState([] as { code: string; name: string }[]);
   const [currencies, setCurrencies] = useState([] as { code: string; description: string }[]);
+  const [customerPostingGroups, setCustomerPostingGroups] = useState<string[]>([]);
   const [startData, setStartData] = useState<any>(null);
   const [baseCalendarOptions, setBaseCalendarOptions] = useState(['STANDARD']);
   const [showAI, setShowAI] = useState(false);
@@ -321,6 +322,9 @@ function App() {
         });
         logDebug(`Currency: prepared ${simple.length} rows for grid`);
         setCurrencyRows(simple);
+
+        const groupRows = findTableRows(data, 92) || [];
+        setCustomerPostingGroups(extractFieldValues(groupRows, 'Code'));
 
       } catch (e) {
         console.error('Failed to load starting data', e);
@@ -1204,6 +1208,10 @@ function App() {
               formData={formData}
               confirmed={customersDone}
               setConfirmed={setCustomersDone}
+              countries={countries}
+              currencies={currencies}
+              currencyRows={currencyRows}
+              postingGroups={customerPostingGroups}
             />
           )}
           {step === 8 && <VendorsPage rows={vendorRows} next={next} back={back} />}

--- a/src/components/DatalistCellEditor.tsx
+++ b/src/components/DatalistCellEditor.tsx
@@ -1,0 +1,38 @@
+import React, { useState, useRef, forwardRef, useImperativeHandle } from 'react';
+
+interface Props {
+  values: string[];
+}
+
+const DatalistCellEditor = forwardRef<HTMLInputElement, Props>((props, ref) => {
+  const [value, setValue] = useState(props.values.includes(props.value) ? props.value : props.value || '');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listId = useRef('list-' + Math.random().toString(36).slice(2));
+
+  useImperativeHandle(ref, () => ({
+    getValue: () => value,
+    afterGuiAttached: () => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    },
+  }));
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        list={listId.current}
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        style={{ width: '100%' }}
+      />
+      <datalist id={listId.current}>
+        {props.values.map(v => (
+          <option key={v} value={v} />
+        ))}
+      </datalist>
+    </>
+  );
+});
+
+export default DatalistCellEditor;

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -15,6 +15,7 @@ import {
 import { askOpenAI, parseAIGrid } from '../utils/ai';
 import AISuggestionModal from '../components/AISuggestionModal';
 import { ExcelIcon } from '../components/Icons';
+import DatalistCellEditor from '../components/DatalistCellEditor';
 
 interface Props {
   rows: Record<string, string>[];
@@ -25,6 +26,10 @@ interface Props {
   formData: { [key: string]: any };
   confirmed: boolean;
   setConfirmed: (val: boolean) => void;
+  countries: { code: string; name: string }[];
+  currencies: { code: string; description: string }[];
+  currencyRows: Record<string, string>[];
+  postingGroups: string[];
 }
 
 export default function CustomersPage({
@@ -36,6 +41,10 @@ export default function CustomersPage({
   formData,
   confirmed,
   setConfirmed,
+  countries,
+  currencies,
+  currencyRows,
+  postingGroups,
 }: Props) {
   const [fields, setFields] = useState<TableField[]>([]);
   const [rowData, setRowData] = useState<Record<string, string>[]>([]);
@@ -64,9 +73,30 @@ export default function CustomersPage({
     setRowData(filterRows(fields, rows));
   }, [rows, fields]);
 
+  const lookupOpts = useMemo(() => {
+    const currencyCodes = Array.from(
+      new Set([
+        ...currencies.map(c => c.code),
+        ...currencyRows.map(r => r.Code).filter(Boolean),
+      ]),
+    );
+    const countryCodes = countries.map(c => c.code);
+    const postingCodes = Array.from(
+      new Set([
+        ...postingGroups,
+        ...rowData.map(r => r.CustomerPostingGroup).filter(Boolean),
+      ]),
+    );
+    return {
+      CurrencyCode: currencyCodes,
+      CountryRegionCode: countryCodes,
+      CustomerPostingGroup: postingCodes,
+    } as Record<string, string[]>;
+  }, [countries, currencies, currencyRows, postingGroups, rowData]);
+
   const columnDefs = useMemo(
-    () => createColumnDefs(rowData, fields),
-    [rowData, fields],
+    () => createColumnDefs(rowData, fields, lookupOpts),
+    [rowData, fields, lookupOpts],
   );
 
   const bottomRowData = useMemo(
@@ -217,6 +247,7 @@ export default function CustomersPage({
           ref={gridRef}
           rowData={rowData}
           columnDefs={columnDefs}
+          frameworkComponents={{ datalistEditor: DatalistCellEditor }}
           pinnedBottomRowData={bottomRowData}
           onCellClicked={onCellClicked}
           rowSelection="multiple"

--- a/src/utils/grid.ts
+++ b/src/utils/grid.ts
@@ -4,6 +4,8 @@ export interface ColumnDef {
   sortable?: boolean;
   filter?: boolean;
   editable?: boolean;
+  cellEditor?: any;
+  cellEditorParams?: any;
 }
 
 import type { TableField } from './schema';
@@ -26,24 +28,27 @@ export function filterRows(
 export function createColumnDefs(
   rowData: Record<string, string>[],
   fields: TableField[],
+  lookups?: Record<string, string[]>,
 ): ColumnDef[] {
-  if (!fields.length) {
-    if (!rowData.length) return [];
-    return Object.keys(rowData[0]).map(key => ({
-      headerName: key,
-      field: key,
-      sortable: true,
-      filter: true,
-      editable: true,
-    }));
-  }
-  return fields.map(f => ({
-    headerName: f.name,
-    field: f.xmlName,
-    sortable: true,
-    filter: true,
-    editable: true,
-  }));
+  const defs = (fields.length
+    ? fields.map(f => ({ headerName: f.name, field: f.xmlName }))
+    : Object.keys(rowData[0] || {}).map(key => ({ headerName: key, field: key }))
+  ) as ColumnDef[];
+
+  return defs.map(d => {
+    const opts = lookups?.[d.field];
+    if (opts && opts.length) {
+      return {
+        ...d,
+        sortable: true,
+        filter: true,
+        editable: true,
+        cellEditor: 'datalistEditor',
+        cellEditorParams: { values: opts },
+      } as ColumnDef;
+    }
+    return { ...d, sortable: true, filter: true, editable: true } as ColumnDef;
+  });
 }
 
 export function createBottomRowData(


### PR DESCRIPTION
## Summary
- add DatalistCellEditor for AG Grid dropdowns with typing
- support lookup options in grid column definitions
- load Customer Posting Group data
- add dropdown support for Customer grid fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a76c465bc832293c90fe6bc6044c9