### PR TITLE
Add Chart of Accounts page

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -22,6 +22,7 @@ export default {
   customers: 'Customers',
   vendors: 'Vendors',
   items: 'Items',
+  chartOfAccounts: 'Chart of Accounts',
   currencies: 'Currencies',
   search: 'Search',
   help: 'Get Help from your Partner',

--- a/src/pages/ChartOfAccountsPage.tsx
+++ b/src/pages/ChartOfAccountsPage.tsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useMemo, useState, useRef } from 'react';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-alpine.css';
+import strings from '../../res/strings';
+import { getTableFields, TableField } from '../utils/schema';
+import {
+  filterRows,
+  createColumnDefs,
+  createBottomRowData,
+  createEmptyRow,
+  parseFileUpload,
+  createTemplateBlob,
+} from '../utils/grid';
+import { askOpenAI, parseAIGrid } from '../utils/ai';
+import AISuggestionModal from '../components/AISuggestionModal';
+import { ExcelIcon } from '../components/Icons';
+
+interface Props {
+  rows: Record<string, string>[];
+  setRows: (rows: Record<string, string>[]) => void;
+  next: () => void;
+  back: () => void;
+  logDebug?: (msg: string) => void;
+  formData: { [key: string]: any };
+  confirmed: boolean;
+  setConfirmed: (val: boolean) => void;
+}
+
+export default function ChartOfAccountsPage({
+  rows,
+  setRows,
+  next,
+  back,
+  logDebug,
+  formData,
+  confirmed,
+  setConfirmed,
+}: Props) {
+  const [fields, setFields] = useState<TableField[]>([]);
+  const [rowData, setRowData] = useState<Record<string, string>[]>([]);
+  const [showAI, setShowAI] = useState(false);
+  const [aiRows, setAiRows] = useState<Record<string, string>[]>([]);
+  const [aiExplanation, setAiExplanation] = useState('');
+  const [aiLoading, setAiLoading] = useState(false);
+  const gridRef = useRef<AgGridReact<Record<string, string>>>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  function openFileDialog() {
+    fileInputRef.current?.click();
+  }
+
+  useEffect(() => {
+    getTableFields('G/L Account', true).then(setFields);
+  }, []);
+
+  useEffect(() => {
+    if (logDebug) logDebug(`ChartOfAccountsPage: loading grid with ${rows.length} rows`);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows]);
+
+  useEffect(() => {
+    setRowData(filterRows(fields, rows));
+  }, [rows, fields]);
+
+  const columnDefs = useMemo(
+    () => createColumnDefs(rowData, fields),
+    [rowData, fields],
+  );
+
+  const bottomRowData = useMemo(
+    () => createBottomRowData(columnDefs),
+    [columnDefs],
+  );
+
+  function addRow() {
+    const obj = createEmptyRow(fields, rowData);
+    const updated = [...rowData, obj];
+    setRowData(updated);
+    setRows(updated);
+  }
+
+  function deleteSelected() {
+    const api = gridRef.current?.api;
+    if (!api) return;
+    const selected = api.getSelectedRows();
+    if (!selected.length) return;
+    const updated = rowData.filter(r => !selected.includes(r));
+    setRowData(updated);
+    setRows(updated);
+  }
+
+  async function askAIForGrid(
+    extra: string = '',
+    currentRows?: Record<string, string>[],
+  ) {
+    try {
+      setShowAI(true);
+      setAiLoading(true);
+      const prompt =
+        'Given the following company setup data as JSON:\n' +
+        JSON.stringify(formData, null, 2) +
+        '\nCurrent chart of accounts rows:\n' +
+        JSON.stringify(currentRows ?? rowData, null, 2) +
+        '\nSuggest the best rows for the chart of accounts table. ' +
+        'Return JSON with a "rows" array and an "explanation" string no longer than 500 characters.' +
+        (extra ? `\nAdditional Instructions:\n${extra}` : '');
+      const ans = await askOpenAI(prompt, logDebug);
+      const parsed = parseAIGrid(ans);
+      setAiRows(filterRows(fields, parsed.rows));
+      setAiExplanation(parsed.explanation);
+    } catch (e) {
+      console.error(e);
+      setAiRows([]);
+      setAiExplanation('Failed to get AI suggestion');
+    } finally {
+      setAiLoading(false);
+    }
+  }
+
+  function acceptAI() {
+    setRowData(aiRows);
+    setRows(aiRows);
+    setShowAI(false);
+  }
+
+  function suggestAgain(extra: string) {
+    askAIForGrid(extra, aiRows);
+  }
+
+  function onCellValueChanged(params: any) {
+    const updated = [...rowData];
+    updated[params.rowIndex] = {
+      ...updated[params.rowIndex],
+      [params.column.getColId()]: params.newValue,
+    };
+    setRowData(updated);
+    setRows(updated);
+  }
+
+  function onCellClicked(params: any) {
+    if (params.node.rowPinned === 'bottom') {
+      addRow();
+    }
+  }
+
+  async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const rowsParsed = await parseFileUpload(file, fields);
+      if (rowsParsed.length) {
+        setRowData(rowsParsed);
+        setRows(rowsParsed);
+      }
+    } catch (err) {
+      console.error('Failed to parse file', err);
+    } finally {
+      e.target.value = '';
+    }
+  }
+
+  function downloadTemplate() {
+    const blob = createTemplateBlob('G_L_Account', rowData, fields);
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'chart_of_accounts_template.xlsx';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function handleConfirm() {
+    if (confirmed) {
+      setConfirmed(false);
+    } else {
+      next();
+    }
+  }
+
+  return (
+    <div>
+      <div className="section-header">{strings.chartOfAccounts}</div>
+      {confirmed && <div className="confirmed-banner">Confirmed!</div>}
+      <p>You can add, edit, or delete accounts directly below:</p>
+      <div className="grid-toolbar">
+        <button type="button" className="grid-action-btn" onClick={addRow}>
+          Add Row
+        </button>
+        <button
+          type="button"
+          className="grid-action-btn"
+          onClick={deleteSelected}
+        >
+          Delete Selected
+        </button>
+        <button
+          type="button"
+          className="ai-btn"
+          onClick={() => askAIForGrid()}
+        >
+          <span className="icon">✨</span> Ask AI to Help
+        </button>
+      </div>
+      <div
+        className="ag-theme-alpine chart-grid"
+        style={{ height: 400, width: '100%' }}
+        tabIndex={0}
+        onFocus={() => {
+          if (!gridRef.current || !columnDefs.length) return;
+          gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+        }}
+      >
+        <AgGridReact
+          ref={gridRef}
+          rowData={rowData}
+          columnDefs={columnDefs}
+          pinnedBottomRowData={bottomRowData}
+          onCellClicked={onCellClicked}
+          rowSelection="multiple"
+          rowHeight={36}
+          singleClickEdit={true}
+          onCellFocused={e => {
+            if (e.rowIndex == null || !e.column) return;
+            gridRef.current?.api.startEditingCell({
+              rowIndex: e.rowIndex,
+              colKey: e.column.getColId(),
+            });
+          }}
+          onCellValueChanged={onCellValueChanged}
+          defaultColDef={{ flex: 1, resizable: true, editable: true }}
+        />
+      </div>
+      <div className="file-controls">
+        <input
+          type="file"
+          accept=".xlsx,.csv"
+          onChange={handleFileUpload}
+          ref={fileInputRef}
+          style={{ display: 'none' }}
+        />
+        <button
+          type="button"
+          className="download-template-btn"
+          onClick={openFileDialog}
+        >
+          Upload CSV/XSLX
+        </button>
+        <button
+          type="button"
+          className="download-template-link"
+          onClick={downloadTemplate}
+        >
+          <ExcelIcon className="excel-icon" /> Download Template
+        </button>
+      </div>
+      <div className="divider" />
+      <div className="nav">
+        <button className="skip-btn" onClick={back}>{strings.back}</button>
+        <button className="next-btn" onClick={handleConfirm}>
+          {confirmed ? 'Mark as Not Confirmed' : 'Confirm'}
+        </button>
+        {!confirmed && (
+          <button className="skip-btn skip-right" onClick={next}>
+            {strings.skip}
+          </button>
+        )}
+      </div>
+      <AISuggestionModal
+        show={showAI}
+        rows={aiRows}
+        columnDefs={columnDefs}
+        explanation={aiExplanation}
+        loading={aiLoading}
+        onAccept={acceptAI}
+        onClose={() => setShowAI(false)}
+        onSuggestAgain={suggestAgain}
+      />
+    </div>
+  );
+}

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -22,6 +22,7 @@ interface Props {
   goToCustomers: () => void;
   goToVendors: () => void;
   goToItems: () => void;
+  goToChartOfAccounts: () => void;
   goToCurrencies: () => void;
   goToCustomerTemplate: () => void;
   goToVendorTemplate: () => void;
@@ -45,6 +46,7 @@ interface Props {
   customersDone: boolean;
   vendorsDone: boolean;
   itemsDone: boolean;
+  chartDone: boolean;
   currenciesDone: boolean;
 }
 
@@ -57,6 +59,7 @@ function ConfigMenuPage({
   goToCustomers,
   goToVendors,
   goToItems,
+  goToChartOfAccounts,
   goToCurrencies,
   goToCustomerTemplate,
   goToVendorTemplate,
@@ -80,6 +83,7 @@ function ConfigMenuPage({
   customersDone,
   vendorsDone,
   itemsDone,
+  chartDone,
   currenciesDone,
 }: Props) {
   const nothingConfirmed =
@@ -90,6 +94,7 @@ function ConfigMenuPage({
     !customersDone &&
     !vendorsDone &&
     !itemsDone &&
+    !chartDone &&
     !currenciesDone;
   return (
     <div>
@@ -219,6 +224,18 @@ function ConfigMenuPage({
             {itemsDone && <div className="checkmark">✔</div>}
             <CubeIcon />
             <div>{strings.items}</div>
+          </div>
+          <div
+            className={`menu-box ${chartDone ? 'done' : ''}`}
+            onClick={goToChartOfAccounts}
+            tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') goToChartOfAccounts();
+            }}
+          >
+            {chartDone && <div className="checkmark">✔</div>}
+            <BookIcon />
+            <div>{strings.chartOfAccounts}</div>
           </div>
           <div
             className={`menu-box ${currenciesDone ? 'done' : ''}`}

--- a/style.css
+++ b/style.css
@@ -1012,6 +1012,18 @@ h3 {
   --ag-grid-size: 6px;
 }
 
+/* Chart of Accounts grid theme tweaks - same as currency grid */
+.chart-grid {
+  --ag-header-background-color: var(--bc-gray);
+  --ag-header-foreground-color: var(--bc-text);
+  --ag-row-hover-color: var(--bc-gray);
+  --ag-odd-row-background-color: #fafafa;
+  --ag-border-color: #e1dfdd;
+  --ag-row-height: 36px;
+  --ag-header-height: 38px;
+  --ag-grid-size: 6px;
+}
+
 .download-template-btn {
   background: transparent;
   border: 1px solid var(--bc-blue);
@@ -1050,6 +1062,17 @@ h3 {
 }
 
 .customer-grid .ag-row-pinned-bottom .ag-cell:hover {
+  color: var(--bc-blue-dark);
+}
+
+.chart-grid .ag-row-pinned-bottom .ag-cell {
+  justify-content: center;
+  cursor: pointer;
+  color: var(--bc-blue);
+  font-size: 1.5em;
+}
+
+.chart-grid .ag-row-pinned-bottom .ag-cell:hover {
   color: var(--bc-blue-dark);
 }
 


### PR DESCRIPTION
## Summary
- add `ChartOfAccountsPage` for editing G/L accounts
- show Chart of Accounts menu option
- load chart account rows from sample data
- support confirmation status for chart of accounts
- style grid for chart of accounts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a79205c4c8322bf4ae656e14917c1