### PR TITLE
Fix grid cell focus

### DIFF
--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -263,7 +263,9 @@ export default function CustomersPage({
         tabIndex={0}
         onFocus={() => {
           if (!gridRef.current || !columnDefs.length) return;
-          gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+          if (!gridRef.current.api.getFocusedCell()) {
+            gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+          }
         }}
       >
         <AgGridReact

--- a/src/pages/VendorsPage.tsx
+++ b/src/pages/VendorsPage.tsx
@@ -37,7 +37,9 @@ export default function VendorsPage({ rows, next, back }: Props) {
         tabIndex={0}
         onFocus={() => {
           if (!gridRef.current || !columnDefs.length) return;
-          gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+          if (!gridRef.current.api.getFocusedCell()) {
+            gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+          }
         }}
       >
         <AgGridReact


### PR DESCRIPTION
## Summary
- keep focused cell when grid container receives focus
- apply same logic to Vendors grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7ded12f4832287f43290046b7e9f