### PR TITLE
Fix grid focus for currency page and enable dropdown cell editors

### DIFF
--- a/src/pages/CurrencyPage.tsx
+++ b/src/pages/CurrencyPage.tsx
@@ -210,7 +210,9 @@ export default function CurrencyPage({
         tabIndex={0}
         onFocus={() => {
           if (!gridRef.current || !columnDefs.length) return;
-          gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+          if (!gridRef.current.api.getFocusedCell()) {
+            gridRef.current.api.setFocusedCell(0, columnDefs[0].field);
+          }
         }}
       >
         <AgGridReact

--- a/src/utils/grid.ts
+++ b/src/utils/grid.ts
@@ -41,7 +41,7 @@ export function createColumnDefs(
         editable: true,
       };
       if (dropdowns[key]) {
-        def.cellEditor = "agRichSelectCellEditor";
+        def.cellEditor = "agSelectCellEditor";
         def.cellEditorParams = { values: dropdowns[key] };
       }
       return def;
@@ -56,7 +56,7 @@ export function createColumnDefs(
       editable: true,
     };
     if (dropdowns[f.xmlName]) {
-      def.cellEditor = "agRichSelectCellEditor";
+      def.cellEditor = "agSelectCellEditor";
       def.cellEditorParams = { values: dropdowns[f.xmlName] };
     }
     return def;


### PR DESCRIPTION
## Summary
- ensure currencies grid only resets focus when needed
- use `agSelectCellEditor` so dropdowns show without enterprise modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7ff4e84c83228abfe4c4724da908