### PR TITLE
Add info popup for AI recommendations

### DIFF
--- a/src/components/FieldSubPage.tsx
+++ b/src/components/FieldSubPage.tsx
@@ -3,7 +3,8 @@ import { CompanyField } from '../types';
 import { fieldKey } from '../utils/helpers';
 
 import strings from '../../res/strings';
-import { LightbulbIcon, SparkleIcon } from './Icons';
+import { LightbulbIcon, SparkleIcon, InfoIcon } from './Icons';
+import InfoPopup from './InfoPopup';
 
 interface Props {
   field: CompanyField;
@@ -17,7 +18,7 @@ interface Props {
   fetchAISuggestion?: (
     field: CompanyField,
     currentValue: string
-  ) => Promise<{ suggested: string; confidence: string }>;
+  ) => Promise<{ suggested: string; confidence: string; reasoning: string }>;
   setFieldValue?: (key: string, value: string) => void;
   confirmLabel?: string;
   confirmed?: boolean;
@@ -39,7 +40,8 @@ function FieldSubPage({
 }: Props) {
   const isFinal = !confirmed && confirmLabel === 'Confirm and Finish';
   const buttonLabel = confirmed ? 'Mark as Not Confirmed' : confirmLabel;
-  const [auto, setAuto] = useState<{ suggested: string; confidence: string } | null>(null);
+  const [auto, setAuto] = useState<{ suggested: string; confidence: string; reasoning: string } | null>(null);
+  const [showInfo, setShowInfo] = useState(false);
   const key = fieldKey(cf.field);
   const value = formData ? formData[key] || '' : '';
 
@@ -88,6 +90,12 @@ function FieldSubPage({
             <SparkleIcon className="sparkle-icon" />
             <div>
               <strong>AI Recommends:</strong> {auto!.suggested}
+              {auto!.reasoning && (
+                <InfoIcon
+                  className="info-icon"
+                  onClick={() => setShowInfo(true)}
+                />
+              )}
               {setFieldValue && (
                 <button
                   type="button"
@@ -117,6 +125,11 @@ function FieldSubPage({
           <button className="skip-btn" onClick={onSkip}>Skip</button>
         )}
       </div>
+      <InfoPopup
+        show={showInfo}
+        reasoning={auto?.reasoning || ''}
+        onClose={() => setShowInfo(false)}
+      />
     </div>
   );
 }

--- a/src/components/FieldWizard.tsx
+++ b/src/components/FieldWizard.tsx
@@ -21,7 +21,7 @@ interface Props {
   fetchAISuggestion: (
     field: CompanyField,
     currentValue: string
-  ) => Promise<{ suggested: string; confidence: string }>;
+  ) => Promise<{ suggested: string; confidence: string; reasoning: string }>;
   setFieldValue: (key: string, value: string) => void;
   onFieldIndexChange?: (index: number | null) => void;
   /**

--- a/src/components/InfoPopup.tsx
+++ b/src/components/InfoPopup.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface Props {
+  show: boolean;
+  reasoning: string;
+  onClose: () => void;
+}
+
+export default function InfoPopup({ show, reasoning, onClose }: Props) {
+  if (!show) return null;
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        <p style={{ whiteSpace: 'pre-wrap' }}>{reasoning}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/WizardPage.tsx
+++ b/src/pages/WizardPage.tsx
@@ -18,7 +18,7 @@ export interface WizardPageProps {
   fetchAISuggestion: (
     field: CompanyField,
     currentValue: string
-  ) => Promise<{ suggested: string; confidence: string }>;
+  ) => Promise<{ suggested: string; confidence: string; reasoning: string }>;
   setFieldValue: (key: string, value: string) => void;
   onFieldIndexChange: (index: number | null) => void;
   goToFieldIndex?: number | null;

--- a/style.css
+++ b/style.css
@@ -844,6 +844,15 @@ h3 {
   margin-left: 8px;
 }
 
+.auto-suggest .info-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--bc-blue);
+  cursor: pointer;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
 
 .confirmed-banner {
   background: var(--bc-teal);


### PR DESCRIPTION
## Summary
- show an info icon beside AI recommendations
- clicking the icon shows a popup explaining the suggestion
- wire reasoning through wizard pages
- style the info icon

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a8a5abbd0832299bb68e19174c227