### PR TITLE
Improve grid dropdown hover visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -1116,3 +1116,11 @@ h3 {
 }
 
 
+
+/* Highlight options on hover in grid dropdowns */
+.ag-select-cell-editor option:hover,
+.ag-cell-edit-input option:hover {
+  background-color: var(--bc-gray);
+  color: var(--bc-text);
+}
+


### PR DESCRIPTION
## Summary
- tweak CSS for grid dropdowns so options highlight when hovering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a8c20a00883228ddb59c0493b29da