### PR TITLE
Fix duplicate default currency options

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -888,9 +888,12 @@ function App() {
       inputEl = <input {...inputProps} />;
     } else if (cf.lookupTable && startData) {
       const rows = findTableRows(startData, cf.lookupTable) || [];
-      const opts = extractFieldValues(rows, cf.lookupField || "Code");
+      let opts = extractFieldValues(rows, cf.lookupField || "Code");
       const isCurrency = cf.lookupTable === 4;
       const lcy = formData[fieldKey("Local Currency (LCY) Code")] || "";
+      if (isCurrency && lcy) {
+        opts = opts.filter((o) => o !== lcy);
+      }
       const defText = isCurrency ? defaultCurrencyText(lcy) : "";
       inputEl = (
         <select {...inputProps}>

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -102,8 +102,12 @@ export default function CustomersPage({
 
   const dropdowns = useMemo(() => {
     const map: Record<string, string[]> = {};
-    if (currencyField)
-      map[currencyField] = [defaultCurrency, ...currencies.map((c) => c.code)];
+    if (currencyField) {
+      const others = currencies
+        .filter((c) => c.code !== localCurrency)
+        .map((c) => c.code);
+      map[currencyField] = [defaultCurrency, ...others];
+    }
     if (countryField) map[countryField] = countries.map((c) => c.code);
     if (postingField) map[postingField] = postingGroups;
     return map;


### PR DESCRIPTION
## Summary
- prevent duplication of local currency in dropdowns
- remove LCY code from customer grid dropdowns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a8d6fbdc883229f3e34e964204292