### PR TITLE
Fix duplicate default currency options

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -888,10 +888,16 @@ function App() {
       inputEl = <input {...inputProps} />;
     } else if (cf.lookupTable && startData) {
       const rows = findTableRows(startData, cf.lookupTable) || [];
-      const opts = extractFieldValues(rows, cf.lookupField || "Code");
+      let opts = extractFieldValues(rows, cf.lookupField || "Code");
       const isCurrency = cf.lookupTable === 4;
       const lcy = formData[fieldKey("Local Currency (LCY) Code")] || "";
-      const defText = isCurrency ? defaultCurrencyText(lcy) : "";
+      if (isCurrency && lcy) {
+        const norm = lcy.trim().toLowerCase();
+        opts = opts.filter((o) => o.trim().toLowerCase() !== norm && o.trim() !== "");
+      } else {
+        opts = opts.filter((o) => o.trim() !== "");
+      }
+      const defText = isCurrency ? defaultCurrencyText(lcy.trim()) : "";
       inputEl = (
         <select {...inputProps}>
           <option value="">{defText}</option>

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -96,14 +96,23 @@ export default function CustomersPage({
     [formData],
   );
   const defaultCurrency = useMemo(
-    () => defaultCurrencyText(localCurrency),
+    () => defaultCurrencyText(localCurrency.trim()),
     [localCurrency],
   );
 
   const dropdowns = useMemo(() => {
     const map: Record<string, string[]> = {};
-    if (currencyField)
-      map[currencyField] = [defaultCurrency, ...currencies.map((c) => c.code)];
+    if (currencyField) {
+      const norm = localCurrency.trim().toLowerCase();
+      const others = Array.from(
+        new Set(
+          currencies
+            .map((c) => c.code.trim())
+            .filter((c) => c && c.toLowerCase() !== norm),
+        ),
+      );
+      map[currencyField] = [defaultCurrency, ...others];
+    }
     if (countryField) map[countryField] = countries.map((c) => c.code);
     if (postingField) map[postingField] = postingGroups;
     return map;


### PR DESCRIPTION
## Summary
- clean whitespace before building default currency text
- exclude LCY code from dropdowns using trim and dedup logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a8d6fbdc883229f3e34e964204292