### PR TITLE
Add dropdown hover styling

### DIFF
--- a/src/utils/grid.ts
+++ b/src/utils/grid.ts
@@ -43,7 +43,8 @@ export function createColumnDefs(
         editable: true,
       };
       if (dropdowns[key]) {
-        def.cellEditor = "agSelectCellEditor";
+        def.cellEditor = "agRichSelectCellEditor";
+        def.cellEditorPopup = true;
         const values = dropdowns[key].includes('')
           ? dropdowns[key]
           : ['', ...dropdowns[key]];
@@ -61,7 +62,8 @@ export function createColumnDefs(
       editable: true,
     };
     if (dropdowns[f.xmlName]) {
-      def.cellEditor = "agSelectCellEditor";
+      def.cellEditor = "agRichSelectCellEditor";
+      def.cellEditorPopup = true;
       const values = dropdowns[f.xmlName].includes('')
         ? dropdowns[f.xmlName]
         : ['', ...dropdowns[f.xmlName]];

--- a/style.css
+++ b/style.css
@@ -1132,3 +1132,10 @@ select option:checked {
   color: var(--bc-text);
 }
 
+/* Rich select dropdown (AG Grid) */
+.ag-rich-select-row:hover,
+.ag-rich-select-row[aria-selected='true'] {
+  background-color: var(--bc-gray);
+  color: var(--bc-text);
+}
+


### PR DESCRIPTION
## Summary
- improve grid dropdown hover styling
- use AG Grid rich select editor for dropdowns

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a96811db48322a9b3b07c91cc91d9