### PR TITLE
Enable hover on grid dropdown options

### DIFF
--- a/src/utils/grid.ts
+++ b/src/utils/grid.ts
@@ -5,6 +5,7 @@ export interface ColumnDef {
   filter?: boolean;
   editable?: boolean;
   cellEditor?: string;
+  cellEditorPopup?: boolean;
   cellEditorParams?: any;
   valueFormatter?: (params: any) => string;
   valueParser?: (params: any) => any;
@@ -43,7 +44,8 @@ export function createColumnDefs(
         editable: true,
       };
       if (dropdowns[key]) {
-        def.cellEditor = "agSelectCellEditor";
+        def.cellEditor = "agRichSelectCellEditor";
+        def.cellEditorPopup = true;
         const values = dropdowns[key].includes('')
           ? dropdowns[key]
           : ['', ...dropdowns[key]];
@@ -61,7 +63,8 @@ export function createColumnDefs(
       editable: true,
     };
     if (dropdowns[f.xmlName]) {
-      def.cellEditor = "agSelectCellEditor";
+      def.cellEditor = "agRichSelectCellEditor";
+      def.cellEditorPopup = true;
       const values = dropdowns[f.xmlName].includes('')
         ? dropdowns[f.xmlName]
         : ['', ...dropdowns[f.xmlName]];

--- a/style.css
+++ b/style.css
@@ -1155,3 +1155,11 @@ select option:checked {
   color: var(--bc-text) !important;
 }
 
+/* Highlight options in ag-rich-select dropdowns */
+.ag-rich-select-row:hover,
+.ag-rich-select-row.ag-rich-select-row-selected,
+.ag-rich-select-row.ag-rich-select-row-highlight {
+  background-color: var(--bc-gray) !important;
+  color: var(--bc-text) !important;
+}
+


### PR DESCRIPTION
## Summary
- support pop-up rich select editor for grid dropdowns
- style rich select rows to highlight on hover or selection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a9aae58488322813d50cbae830188