### PR TITLE
Refactor wizard page wrappers

### DIFF
--- a/src/pages/CompanyInfoPage.tsx
+++ b/src/pages/CompanyInfoPage.tsx
@@ -1,8 +1,4 @@
 import strings from '../../res/strings';
-import WizardPage, { WizardPageProps } from './WizardPage';
+import { createWizardPage } from './WizardPage';
 
-export default function CompanyInfoPage(
-  props: Omit<WizardPageProps, 'title' | 'skipSection'>
-) {
-  return <WizardPage {...props} title={strings.companyInfo} />;
-}
+export default createWizardPage(strings.companyInfo);

--- a/src/pages/GLSetupPage.tsx
+++ b/src/pages/GLSetupPage.tsx
@@ -1,8 +1,4 @@
 import strings from '../../res/strings';
-import WizardPage, { WizardPageProps } from './WizardPage';
+import { createWizardPage } from './WizardPage';
 
-export default function GLSetupPage(
-  props: Omit<WizardPageProps, 'title' | 'skipSection'>
-) {
-  return <WizardPage {...props} title={strings.generalLedgerSetup} />;
-}
+export default createWizardPage(strings.generalLedgerSetup);

--- a/src/pages/PurchasePayablesPage.tsx
+++ b/src/pages/PurchasePayablesPage.tsx
@@ -1,8 +1,4 @@
 import strings from '../../res/strings';
-import WizardPage, { WizardPageProps } from './WizardPage';
+import { createWizardPage } from './WizardPage';
 
-export default function PurchasePayablesPage(
-  props: Omit<WizardPageProps, 'title' | 'skipSection'>,
-) {
-  return <WizardPage {...props} title={strings.purchasePayablesSetup} />;
-}
+export default createWizardPage(strings.purchasePayablesSetup);

--- a/src/pages/SalesReceivablesPage.tsx
+++ b/src/pages/SalesReceivablesPage.tsx
@@ -1,8 +1,4 @@
 import strings from '../../res/strings';
-import WizardPage, { WizardPageProps } from './WizardPage';
+import { createWizardPage } from './WizardPage';
 
-export default function SalesReceivablesPage(
-  props: Omit<WizardPageProps, 'title' | 'skipSection'>
-) {
-  return <WizardPage {...props} title={strings.salesReceivablesSetup} />;
-}
+export default createWizardPage(strings.salesReceivablesSetup);

--- a/src/pages/WizardPage.tsx
+++ b/src/pages/WizardPage.tsx
@@ -48,4 +48,12 @@ function WizardPage({ title, fields, renderInput, next, back, skipSection = back
   );
 }
 
+export function createWizardPage(title: string) {
+  return function GeneratedPage(
+    props: Omit<WizardPageProps, 'title' | 'skipSection'>
+  ) {
+    return <WizardPage {...props} title={title} />;
+  };
+}
+
 export default WizardPage;


### PR DESCRIPTION
## Summary
- remove repetitive wrapper logic from several wizard pages
- add `createWizardPage` helper for generating simple wizard pages

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa21550588322a016548905df2d7c