### PR TITLE
Show boolean fields as checkboxes

### DIFF
--- a/src/utils/grid.ts
+++ b/src/utils/grid.ts
@@ -9,9 +9,26 @@ export interface ColumnDef {
   cellEditorParams?: any;
   valueFormatter?: (params: any) => string;
   valueParser?: (params: any) => any;
+  cellRenderer?: (params: any) => any;
+  cellClass?: string;
 }
 
 import type { TableField } from "./schema";
+
+function booleanCellRenderer(params: any) {
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.checked = params.value === "1";
+  input.className = "grid-bool-checkbox";
+  if (params.value === "") {
+    input.classList.add("empty");
+  }
+  input.addEventListener("change", () => {
+    const val = input.checked ? "1" : "0";
+    params.node.setDataValue(params.column.getColId(), val);
+  });
+  return input;
+}
 
 export function filterRows(
   fields: TableField[],
@@ -62,6 +79,11 @@ export function createColumnDefs(
       filter: true,
       editable: true,
     };
+    if (f.fieldType === "Boolean") {
+      def.cellRenderer = booleanCellRenderer;
+      def.cellClass = "boolean-cell";
+      def.editable = false;
+    }
     if (dropdowns[f.xmlName]) {
       def.cellEditor = "agRichSelectCellEditor";
       def.cellEditorPopup = true;

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -26,6 +26,7 @@ async function loadMappings() {
 export interface TableField {
   name: string;
   xmlName: string;
+  fieldType?: string;
 }
 
 export async function getTableFields(
@@ -44,7 +45,8 @@ export async function getTableFields(
         .map((f: any) => {
           const name = String(f['BC Field Name'] || f.Field);
           const xmlName = map[name] || mapFieldName(name);
-          return { name, xmlName };
+          const fieldType = f.FieldType ? String(f.FieldType) : undefined;
+          return { name, xmlName, fieldType };
         });
     }
   }

--- a/style.css
+++ b/style.css
@@ -1163,3 +1163,11 @@ select option:checked {
   color: var(--bc-text) !important;
 }
 
+/* Boolean checkbox cells */
+.boolean-cell {
+  justify-content: center;
+}
+.grid-bool-checkbox.empty {
+  opacity: 0.5;
+}
+


### PR DESCRIPTION
## Summary
- surface field type when loading table fields
- render boolean fields as checkboxes in data grids
- style grid boolean checkbox cells

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa30c622883229699c71345edd559