### PR TITLE
Add Fixed Asset Setup wizard page

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -16,6 +16,7 @@ export default {
   generalLedgerSetup: 'General Ledger Setup',
   salesReceivablesSetup: 'Sales & Receivables Setup',
   purchasePayablesSetup: 'Purchases & Payables Setup',
+  fixedAssetSetup: 'Fixed Asset Setup',
   common: 'Common',
   sometimes: 'Sometimes',
   additional: 'Additional',

--- a/src/fieldNames.ts
+++ b/src/fieldNames.ts
@@ -97,6 +97,12 @@ export const ppFieldNames = [
   'Posted Return Shpt. Nos.',
 ];
 
+export const faFieldNames = [
+  'FA Nos.',
+  'Depreciation Book Nos.',
+  'FA Journal Batch Name',
+];
+
 /**
  * Convert a list of names into basic CompanyField objects.
  */

--- a/src/pages/ConfigMenuPage.tsx
+++ b/src/pages/ConfigMenuPage.tsx
@@ -19,6 +19,7 @@ interface Props {
   goToGLSetup: () => void;
   goToSRSetup: () => void;
   goToPPSetup: () => void;
+  goToFASetup: () => void;
   goToCustomers: () => void;
   goToVendors: () => void;
   goToItems: () => void;
@@ -44,6 +45,8 @@ interface Props {
   srInProgress: boolean;
   ppDone: boolean;
   ppInProgress: boolean;
+  faDone: boolean;
+  faInProgress: boolean;
   customersDone: boolean;
   vendorsDone: boolean;
   itemsDone: boolean;
@@ -58,6 +61,7 @@ function ConfigMenuPage({
   goToGLSetup,
   goToSRSetup,
   goToPPSetup,
+  goToFASetup,
   goToCustomers,
   goToVendors,
   goToItems,
@@ -83,6 +87,8 @@ function ConfigMenuPage({
   srInProgress,
   ppDone,
   ppInProgress,
+  faDone,
+  faInProgress,
   customersDone,
   vendorsDone,
   itemsDone,
@@ -95,6 +101,7 @@ function ConfigMenuPage({
     !companyDone &&
     !glDone &&
     !srDone &&
+    !faDone &&
     !customersDone &&
     !vendorsDone &&
     !itemsDone &&
@@ -188,6 +195,19 @@ function ConfigMenuPage({
             )}
             <BoxIcon />
             <div>{strings.purchasePayablesSetup}</div>
+          </div>
+          <div
+            className={`menu-box ${faDone ? 'done' : ''}`}
+            onClick={goToFASetup}
+            tabIndex={0}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') goToFASetup();
+            }}
+          >
+            {faDone && <div className="checkmark">✔</div>}
+            {!faDone && faInProgress && <div className="progress-dot">•</div>}
+            <BoxIcon />
+            <div>{strings.fixedAssetSetup}</div>
           </div>
         </div>
       </div>

--- a/src/pages/FixedAssetSetupPage.tsx
+++ b/src/pages/FixedAssetSetupPage.tsx
@@ -1,0 +1,4 @@
+import strings from '../../res/strings';
+import { createWizardPage } from './WizardPage';
+
+export default createWizardPage(strings.fixedAssetSetup);


### PR DESCRIPTION
## Summary
- add strings entry for Fixed Asset Setup
- list Fixed Asset Setup fields
- create FixedAssetSetupPage
- wire Fixed Asset Setup into wizard navigation and progress
- update ConfigMenuPage to show Fixed Asset Setup option

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687aa77a20e483229b1ea25ff2bff1c3