### PR TITLE
Support optional setup pages

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -28,6 +28,7 @@ import ContactTemplatePage from './pages/ContactTemplatePage';
 import EmployeeTemplatePage from './pages/EmployeeTemplatePage';
 import ResourceTemplatePage from './pages/ResourceTemplatePage';
 import ReviewPage from './pages/ReviewPage';
+import OptionalSetupPage from './pages/OptionalSetupPage';
 import BCLogo from './images/Dynamics_365_business_Central_Logo.svg';
 import strings from '../res/strings';
 import { CompanyField, BasicInfo } from './types';
@@ -128,6 +129,11 @@ function App() {
   const [showSRSometimes, setShowSRSometimes] = useState(false);
   const [showPPSometimes, setShowPPSometimes] = useState(false);
   const [showFASometimes, setShowFASometimes] = useState(false);
+  const [companyIntro, setCompanyIntro] = useState(false);
+  const [glIntro, setGlIntro] = useState(false);
+  const [srIntro, setSrIntro] = useState(false);
+  const [ppIntro, setPpIntro] = useState(false);
+  const [faIntro, setFaIntro] = useState(false);
   const [aiParsed, setAiParsed] = useState({
     suggested: "",
     confidence: "",
@@ -547,6 +553,9 @@ function App() {
         setCompanyVisited(
           company.filter((f) => f.common === "common").map(() => false),
         );
+        setCompanyIntro(
+          (company[0]?.setupOptional || '').toLowerCase() === 'yes'
+        );
         setFormData((f: FormData) => {
           const copy: FormData = { ...f };
           company.forEach((cf) => {
@@ -560,6 +569,7 @@ function App() {
         setGlFields(gl);
         setGlProgress(gl.filter((f) => f.common === "common").map(() => false));
         setGlVisited(gl.filter((f) => f.common === "common").map(() => false));
+        setGlIntro((gl[0]?.setupOptional || '').toLowerCase() === 'yes');
         setFormData((f: FormData) => {
           const copy: FormData = { ...f };
           gl.forEach((cf) => {
@@ -573,6 +583,7 @@ function App() {
         setSrFields(sr);
         setSrProgress(sr.filter((f) => f.common === "common").map(() => false));
         setSrVisited(sr.filter((f) => f.common === "common").map(() => false));
+        setSrIntro((sr[0]?.setupOptional || '').toLowerCase() === 'yes');
         setFormData((f: FormData) => {
           const copy: FormData = { ...f };
           sr.forEach((cf) => {
@@ -586,6 +597,7 @@ function App() {
         setPpFields(pp);
         setPpProgress(pp.filter((f) => f.common === "common").map(() => false));
         setPpVisited(pp.filter((f) => f.common === "common").map(() => false));
+        setPpIntro((pp[0]?.setupOptional || '').toLowerCase() === 'yes');
         setFormData((f: FormData) => {
           const copy: FormData = { ...f };
           pp.forEach((cf) => {
@@ -599,6 +611,7 @@ function App() {
         setFaFields(fa);
         setFaProgress(fa.filter((f) => f.common === "common").map(() => false));
         setFaVisited(fa.filter((f) => f.common === "common").map(() => false));
+        setFaIntro((fa[0]?.setupOptional || '').toLowerCase() === 'yes');
         setFormData((f: FormData) => {
           const copy: FormData = { ...f };
           fa.forEach((cf) => {
@@ -789,6 +802,16 @@ function App() {
         applyRecommendedValue(cf);
       }
     }
+  }
+
+  function confirmAll(
+    progress: boolean[],
+    setProg: (arr: boolean[]) => void,
+    visited: boolean[],
+    setVisitedArr: (arr: boolean[]) => void,
+  ) {
+    setProg(progress.map(() => true));
+    setVisitedArr(visited.map(() => true));
   }
 
   // Upload a basic RapidStart template to Azure
@@ -1422,7 +1445,30 @@ function App() {
                   setConfirmed={setBasicDone}
                 />
               )}
-              {step === 3 && (
+              {step === 3 && companyIntro && (
+                <OptionalSetupPage
+                  title={strings.companyInfo}
+                  fields={companyFields}
+                  formData={formData}
+                  onUseDefaults={() => {
+                    confirmAll(
+                      companyProgress,
+                      setCompanyProgress,
+                      companyVisited,
+                      setCompanyVisited,
+                    );
+                    setCompanyIntro(false);
+                    next();
+                  }}
+                  onReview={() => {
+                    setCompanyIntro(false);
+                  }}
+                  onSkip={() => {
+                    next();
+                  }}
+                />
+              )}
+              {step === 3 && !companyIntro && (
                 <CompanyInfoPage
                   fields={companyFields}
                   renderInput={renderInput}
@@ -1441,7 +1487,30 @@ function App() {
                   goToFieldIndex={companyFieldIdx}
                 />
               )}
-              {step === 4 && (
+              {step === 4 && glIntro && (
+                <OptionalSetupPage
+                  title={strings.generalLedgerSetup}
+                  fields={glFields}
+                  formData={formData}
+                  onUseDefaults={() => {
+                    confirmAll(
+                      glProgress,
+                      setGlProgress,
+                      glVisited,
+                      setGlVisited,
+                    );
+                    setGlIntro(false);
+                    next();
+                  }}
+                  onReview={() => {
+                    setGlIntro(false);
+                  }}
+                  onSkip={() => {
+                    next();
+                  }}
+                />
+              )}
+              {step === 4 && !glIntro && (
                 <GLSetupPage
                   fields={glFields}
                   renderInput={renderInput}
@@ -1460,7 +1529,30 @@ function App() {
                   goToFieldIndex={glFieldIdx}
                 />
               )}
-              {step === 5 && (
+              {step === 5 && srIntro && (
+                <OptionalSetupPage
+                  title={strings.salesReceivablesSetup}
+                  fields={srFields}
+                  formData={formData}
+                  onUseDefaults={() => {
+                    confirmAll(
+                      srProgress,
+                      setSrProgress,
+                      srVisited,
+                      setSrVisited,
+                    );
+                    setSrIntro(false);
+                    next();
+                  }}
+                  onReview={() => {
+                    setSrIntro(false);
+                  }}
+                  onSkip={() => {
+                    next();
+                  }}
+                />
+              )}
+              {step === 5 && !srIntro && (
                 <SalesReceivablesPage
                   fields={srFields}
                   renderInput={renderInput}
@@ -1479,7 +1571,30 @@ function App() {
                   goToFieldIndex={srFieldIdx}
                 />
               )}
-              {step === 6 && (
+              {step === 6 && ppIntro && (
+                <OptionalSetupPage
+                  title={strings.purchasePayablesSetup}
+                  fields={ppFields}
+                  formData={formData}
+                  onUseDefaults={() => {
+                    confirmAll(
+                      ppProgress,
+                      setPpProgress,
+                      ppVisited,
+                      setPpVisited,
+                    );
+                    setPpIntro(false);
+                    next();
+                  }}
+                  onReview={() => {
+                    setPpIntro(false);
+                  }}
+                  onSkip={() => {
+                    next();
+                  }}
+                />
+              )}
+              {step === 6 && !ppIntro && (
                 <PurchasePayablesPage
                   fields={ppFields}
                   renderInput={renderInput}
@@ -1498,7 +1613,30 @@ function App() {
                   goToFieldIndex={ppFieldIdx}
                 />
               )}
-              {step === 7 && (
+              {step === 7 && faIntro && (
+                <OptionalSetupPage
+                  title={strings.fixedAssetSetup}
+                  fields={faFields}
+                  formData={formData}
+                  onUseDefaults={() => {
+                    confirmAll(
+                      faProgress,
+                      setFaProgress,
+                      faVisited,
+                      setFaVisited,
+                    );
+                    setFaIntro(false);
+                    next();
+                  }}
+                  onReview={() => {
+                    setFaIntro(false);
+                  }}
+                  onSkip={() => {
+                    next();
+                  }}
+                />
+              )}
+              {step === 7 && !faIntro && (
                 <FixedAssetSetupPage
                   fields={faFields}
                   renderInput={renderInput}

--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { CompanyField } from '../types';
+import { fieldKey } from '../utils/helpers';
+
+interface Props {
+  title: string;
+  fields: CompanyField[];
+  formData: { [key: string]: any };
+  onUseDefaults: () => void;
+  onReview: () => void;
+  onSkip: () => void;
+}
+
+export default function OptionalSetupPage({
+  title,
+  fields,
+  formData,
+  onUseDefaults,
+  onReview,
+  onSkip,
+}: Props) {
+  return (
+    <div>
+      <div className="section-header">{title}</div>
+      <div className="question">
+        <div className="question-main">
+          {`Configuring data for "${title}" is optional. Below is the preconfigured data. Would like to use the defaults or go through and review all the choices?`}
+        </div>
+      </div>
+      <table className="defaults-table">
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {fields.map(f => (
+            <tr key={f.field}>
+              <td>{f.field}</td>
+              <td>{String(formData[fieldKey(f.field)] || '')}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="nav">
+        <button className="next-btn" onClick={onUseDefaults}>Use the defaults</button>
+        <button className="next-btn" onClick={onReview}>Let's review all the choices?</button>
+        <button className="skip-btn skip-right" onClick={onSkip}>Decide later</button>
+      </div>
+    </div>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface CompanyField {
   lookupTable?: number;
   lookupField?: string;
   tableId?: number;
+  tableName?: string;
+  setupOptional?: string;
 }
 
 export interface BasicInfo {

--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -18,14 +18,19 @@ export async function loadStartingData(): Promise<any> {
 }
 
 export async function loadConfigTables(): Promise<ConfigQuestion[]> {
-  const resp = await fetch('/BC_Setup_All_Tables_and_Fields_grouped_ordered.json');
+  const resp = await fetch('/BC_Setup_All_Tables_and_Fields_grouped_ordered_with_setup.json');
   const data = await resp.json();
   const fields: ConfigQuestion[] = [];
   if (Array.isArray(data)) {
     data.forEach(t => {
       if (Array.isArray(t.Fields)) {
         t.Fields.forEach((f: ConfigQuestion) =>
-          fields.push({ ...f, tableId: t.Number, tableName: t.Name })
+          fields.push({
+            ...f,
+            tableId: t.Number,
+            tableName: t.Name,
+            SetupOptional: t.SetupOptional,
+          })
         );
       }
     });

--- a/src/utils/jsonParsing.ts
+++ b/src/utils/jsonParsing.ts
@@ -12,6 +12,7 @@ export interface ConfigQuestion {
   'Lookup Field'?: string;
   tableId?: number;
   tableName?: string;
+  SetupOptional?: string;
 }
 
 export function recommendedCode(text: string): string {
@@ -51,6 +52,8 @@ export function parseQuestions(
         ? String((q as any)['Lookup Field'])
         : undefined,
       tableId: q?.tableId,
+      tableName: q?.tableName,
+      setupOptional: q?.SetupOptional,
     };
   });
 }

--- a/style.css
+++ b/style.css
@@ -1172,3 +1172,7 @@ select option:checked {
   opacity: 0.5;
 }
 
+
+.defaults-table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+.defaults-table th, .defaults-table td { border: 1px solid #d0d0d0; padding: 6px 8px; text-align: left; }
+


### PR DESCRIPTION
## Summary
- parse `SetupOptional` from config tables
- add OptionalSetupPage component for skipping detailed configuration
- show OptionalSetupPage before certain wizard steps when SetupOptional is `Yes`
- allow confirming defaults or skipping setup
- load setup data from new JSON file
- style table for showing default field values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab1f2bd3883229ef9a32abd4cca99