### PR TITLE
Update optional defaults table styling

### DIFF
--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -32,15 +32,28 @@ export default function OptionalSetupPage({
           <tr>
             <th>Field</th>
             <th>Value</th>
+            <th>Considerations</th>
           </tr>
         </thead>
         <tbody>
-          {fields.map(f => (
-            <tr key={f.field}>
-              <td>{f.field}</td>
-              <td>{String(formData[fieldKey(f.field)] || '')}</td>
-            </tr>
-          ))}
+          {fields.map(f => {
+            const val = formData[fieldKey(f.field)];
+            const displayValue =
+              f.fieldType === 'Boolean'
+                ? val === '1' || val === 1 || val === true
+                  ? 'True'
+                  : val === '0' || val === 0 || val === false
+                  ? 'False'
+                  : ''
+                : String(val ?? '');
+            return (
+              <tr key={f.field}>
+                <td>{f.field}</td>
+                <td>{displayValue}</td>
+                <td>{f.considerations}</td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       <div className="nav">

--- a/style.css
+++ b/style.css
@@ -1187,16 +1187,20 @@ select option:checked {
   text-align: left;
 }
 .defaults-table th {
-  font-size: 16px;
+  font-size: 15px;
 }
 .defaults-table td {
-  font-size: 14px;
+  font-size: 13px;
 }
 .defaults-table td:nth-child(1) {
   color: #555;
   font-weight: bold;
 }
 .defaults-table td:nth-child(2) {
+  color: #000;
+  font-weight: normal;
+}
+.defaults-table td:nth-child(3) {
   color: #000;
   font-weight: normal;
 }


### PR DESCRIPTION
## Summary
- show consideration notes on the optional defaults page
- display boolean values as True/False
- slightly reduce font size in defaults table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ab95e38788322bf531eb0f3c7fd81