### PR TITLE
Add Hide Uncommon toggle

### DIFF
--- a/res/strings.ts
+++ b/res/strings.ts
@@ -26,6 +26,7 @@ export default {
   currencies: 'Currencies',
   chartOfAccounts: 'Chart of Accounts',
   numberSeries: 'Number Series',
+  hideUncommon: 'Hide uncommon settings',
   search: 'Search',
   help: 'Get Help from your Partner',
   review: 'Review',

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -129,6 +129,7 @@ function App() {
   const [showSRSometimes, setShowSRSometimes] = useState(false);
   const [showPPSometimes, setShowPPSometimes] = useState(false);
   const [showFASometimes, setShowFASometimes] = useState(false);
+  const [hideUncommon, setHideUncommon] = useState(true);
   const [companyIntro, setCompanyIntro] = useState(false);
   const [glIntro, setGlIntro] = useState(false);
   const [srIntro, setSrIntro] = useState(false);
@@ -1075,6 +1076,14 @@ function App() {
           Home
         </div>
         <div className="actions">
+          <label className="toggle-switch">
+            <input
+              type="checkbox"
+              checked={hideUncommon}
+              onChange={() => setHideUncommon(!hideUncommon)}
+            />
+            <span>{strings.hideUncommon}</span>
+          </label>
           <span>{strings.search}</span>
           <button className="help-btn">{strings.help}</button>
         </div>
@@ -1121,7 +1130,8 @@ function App() {
                         .filter(
                           (f) =>
                             f.common === "common" ||
-                            (showCompanySometimes && f.common === "sometimes"),
+                            ((showCompanySometimes || !hideUncommon) &&
+                              f.common === "sometimes"),
                         )
                         .map((f, i) => (
                           <li
@@ -1158,7 +1168,8 @@ function App() {
                         .filter(
                           (f) =>
                             f.common === "common" ||
-                            (showGLSometimes && f.common === "sometimes"),
+                            ((showGLSometimes || !hideUncommon) &&
+                              f.common === "sometimes"),
                         )
                         .map((f, i) => (
                           <li
@@ -1193,7 +1204,8 @@ function App() {
                     .filter(
                       f =>
                         f.common === 'common' ||
-                        (showSRSometimes && f.common === 'sometimes')
+                        ((showSRSometimes || !hideUncommon) &&
+                          f.common === 'sometimes')
                     )
                     .map((f, i) => (
                       <li
@@ -1228,7 +1240,8 @@ function App() {
                     .filter(
                       f =>
                         f.common === 'common' ||
-                        (showPPSometimes && f.common === 'sometimes')
+                        ((showPPSometimes || !hideUncommon) &&
+                          f.common === 'sometimes')
                     )
                     .map((f, i) => (
                       <li

--- a/style.css
+++ b/style.css
@@ -638,6 +638,43 @@ h3 {
   margin-left: auto;
 }
 
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.toggle-switch input[type='checkbox'] {
+  appearance: none;
+  width: 34px;
+  height: 18px;
+  background: #ccc;
+  border-radius: 9px;
+  position: relative;
+  cursor: pointer;
+  outline: none;
+}
+
+.toggle-switch input[type='checkbox']::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.2s;
+}
+
+.toggle-switch input[type='checkbox']:checked {
+  background: var(--bc-blue);
+}
+
+.toggle-switch input[type='checkbox']:checked::before {
+  transform: translateX(16px);
+}
+
 .progress-slider {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- add hideUncommon string for UI text
- add toggle switch styles
- add Hide uncommon settings switch in the top bar
- allow uncommon fields in nav when the switch is off

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aba1e88888322bc236c8edb285414