### PR TITLE
Align header and filter optional pages

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1463,6 +1463,7 @@ function App() {
                   title={strings.companyInfo}
                   fields={companyFields}
                   formData={formData}
+                  hideUncommon={hideUncommon}
                   onUseDefaults={() => {
                     confirmAll(
                       companyProgress,
@@ -1505,6 +1506,7 @@ function App() {
                   title={strings.generalLedgerSetup}
                   fields={glFields}
                   formData={formData}
+                  hideUncommon={hideUncommon}
                   onUseDefaults={() => {
                     confirmAll(
                       glProgress,
@@ -1547,6 +1549,7 @@ function App() {
                   title={strings.salesReceivablesSetup}
                   fields={srFields}
                   formData={formData}
+                  hideUncommon={hideUncommon}
                   onUseDefaults={() => {
                     confirmAll(
                       srProgress,
@@ -1589,6 +1592,7 @@ function App() {
                   title={strings.purchasePayablesSetup}
                   fields={ppFields}
                   formData={formData}
+                  hideUncommon={hideUncommon}
                   onUseDefaults={() => {
                     confirmAll(
                       ppProgress,
@@ -1631,6 +1635,7 @@ function App() {
                   title={strings.fixedAssetSetup}
                   fields={faFields}
                   formData={formData}
+                  hideUncommon={hideUncommon}
                   onUseDefaults={() => {
                     confirmAll(
                       faProgress,

--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -6,6 +6,7 @@ interface Props {
   title: string;
   fields: CompanyField[];
   formData: { [key: string]: any };
+  hideUncommon: boolean;
   onUseDefaults: () => void;
   onReview: () => void;
   onSkip: () => void;
@@ -15,10 +16,14 @@ export default function OptionalSetupPage({
   title,
   fields,
   formData,
+  hideUncommon,
   onUseDefaults,
   onReview,
   onSkip,
 }: Props) {
+  const visibleFields = hideUncommon
+    ? fields.filter(f => f.common === 'common')
+    : fields;
   return (
     <div>
       <div className="section-header">{title}</div>
@@ -36,7 +41,7 @@ export default function OptionalSetupPage({
           </tr>
         </thead>
         <tbody>
-          {fields.map(f => {
+          {visibleFields.map(f => {
             const val = formData[fieldKey(f.field)];
             const displayValue =
               f.fieldType === 'Boolean'

--- a/style.css
+++ b/style.css
@@ -644,6 +644,12 @@ h3 {
   gap: 6px;
 }
 
+.toggle-switch span {
+  display: flex;
+  align-items: center;
+  line-height: 18px;
+}
+
 .toggle-switch input[type='checkbox'] {
   appearance: none;
   width: 34px;


### PR DESCRIPTION
## Summary
- center align the Hide Uncommon Settings toggle
- allow hiding uncommon fields on the optional "Use the defaults" pages

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687abcc4df74832291c98832ad784bbd