### PR TITLE
Add divider line on optional setup page

### DIFF
--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -61,6 +61,7 @@ export default function OptionalSetupPage({
           })}
         </tbody>
       </table>
+      <div className="divider" />
       <div className="nav">
         <button className="next-btn" onClick={onUseDefaults}>Use the defaults</button>
         <button className="next-btn" onClick={onReview}>Review all the choices</button>


### PR DESCRIPTION
## Summary
- improve optional setup page layout with separator before nav buttons

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b507b85408322818907ac24e8feca