### PR TITLE
Add AI guidance on optional setup review

### DIFF
--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { CompanyField } from '../types';
 import { fieldKey } from '../utils/helpers';
+import { askOpenAI } from '../utils/ai';
+import { InfoIcon } from '../components/Icons';
+import InfoPopup from '../components/InfoPopup';
 
 interface Props {
   title: string;
@@ -24,6 +27,37 @@ export default function OptionalSetupPage({
   const visibleFields = hideUncommon
     ? fields.filter(f => f.common === 'common')
     : fields;
+  const [aiAnswer, setAiAnswer] = useState('');
+  const [aiReason, setAiReason] = useState('');
+  const [showInfo, setShowInfo] = useState(false);
+
+  useEffect(() => {
+    async function fetchAI() {
+      try {
+        const defaults: Record<string, any> = {};
+        visibleFields.forEach(f => {
+          defaults[f.field] = formData[fieldKey(f.field)];
+        });
+        const prompt =
+          `You are assisting with configuring Dynamics 365 Business Central. ` +
+          `The company's industry is "${formData.industry}" and that should be heavily considered. ` +
+          `Here is all of the information we know about the company as JSON:\n` +
+          JSON.stringify(formData, null, 2) +
+          `\nHere are the default values for the section "${title}":\n` +
+          JSON.stringify(defaults, null, 2) +
+          `\nIs it necessary that the customer change these defaults? ` +
+          `Respond only in JSON like {"answer":"Yes"|"No","reason":"<200 characters>"}.`;
+        const ans = await askOpenAI(prompt);
+        const cleaned = ans.replace(/```json|```/g, '').trim();
+        const parsed = JSON.parse(cleaned);
+        setAiAnswer(parsed.answer || '');
+        setAiReason(parsed.reason || '');
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    fetchAI();
+  }, [fields, formData, hideUncommon]);
   return (
     <div>
       <div className="section-header">{title}</div>
@@ -64,9 +98,18 @@ export default function OptionalSetupPage({
       <div className="divider" />
       <div className="nav">
         <button className="next-btn" onClick={onUseDefaults}>Use the defaults</button>
-        <button className="next-btn" onClick={onReview}>Review all the choices</button>
+        <div className="review-area">
+          <button className="next-btn" onClick={onReview}>Review all the choices</button>
+          {aiAnswer.trim().toLowerCase() === 'yes' && (
+            <span className="ai-review-hint" onClick={() => setShowInfo(true)}>
+              AI recommends to review the choices
+              <InfoIcon className="info-icon" />
+            </span>
+          )}
+        </div>
         <button className="skip-btn skip-right" onClick={onSkip}>Decide later</button>
       </div>
+      <InfoPopup show={showInfo} reasoning={aiReason} onClose={() => setShowInfo(false)} />
     </div>
   );
 }

--- a/style.css
+++ b/style.css
@@ -1248,3 +1248,34 @@ select option:checked {
   font-weight: normal;
 }
 
+/* AI recommendation on optional page */
+.review-area {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ai-review-hint {
+  font-size: 0.9em;
+  color: var(--bc-blue);
+  display: inline-flex;
+  align-items: center;
+  animation: fadeIn 0.5s ease-in;
+  cursor: pointer;
+}
+
+.ai-review-hint .info-icon {
+  width: 16px;
+  height: 16px;
+  margin-left: 4px;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+


### PR DESCRIPTION
## Summary
- query OpenAI from OptionalSetupPage with full form data and emphasis on industry
- display animated review recommendation with info icon
- style AI recommendation message

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bc34e79d48322a844f7f7162fa655