### PR TITLE
Add AI skip recommendation hint

### DIFF
--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { CompanyField } from '../types';
 import { fieldKey } from '../utils/helpers';
 import { askOpenAI } from '../utils/ai';
-import { InfoIcon } from '../components/Icons';
+import { InfoIcon, SparkleIcon } from '../components/Icons';
 import InfoPopup from '../components/InfoPopup';
 
 interface Props {
@@ -108,6 +108,17 @@ export default function OptionalSetupPage({
           )}
         </div>
         <button className="skip-btn skip-right" onClick={onSkip}>Decide later</button>
+        {aiAnswer.trim().toLowerCase() === 'no' && (
+          <span className="ai-skip-hint">
+            <SparkleIcon className="sparkle-icon" />
+            AI recommends 'Skip It' -- The defaults are fine
+            <InfoIcon
+              className="info-icon"
+              title={aiReason}
+              onClick={() => setShowInfo(true)}
+            />
+          </span>
+        )}
       </div>
       <InfoPopup show={showInfo} reasoning={aiReason} onClose={() => setShowInfo(false)} />
     </div>

--- a/style.css
+++ b/style.css
@@ -1270,6 +1270,29 @@ select option:checked {
   margin-left: 4px;
 }
 
+.ai-skip-hint {
+  font-size: 0.9em;
+  color: var(--bc-purple);
+  display: inline-flex;
+  align-items: center;
+  animation: fadeIn 0.5s ease-in;
+  margin-left: 10px;
+}
+
+.ai-skip-hint .sparkle-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+  color: var(--bc-purple);
+}
+
+.ai-skip-hint .info-icon {
+  width: 16px;
+  height: 16px;
+  margin-left: 4px;
+  cursor: pointer;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;


### PR DESCRIPTION
## Summary
- show 'Skip It' suggestion when AI advises not to change defaults
- style AI skip hint with sparkle icon and info popup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bcc9915a883229ffaeb3353b9e2a5