### PR TITLE
Add AI skip recommendation hint

### DIFF
--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { CompanyField } from '../types';
 import { fieldKey } from '../utils/helpers';
 import { askOpenAI } from '../utils/ai';
-import { InfoIcon } from '../components/Icons';
+import { InfoIcon, SparkleIcon } from '../components/Icons';
 import InfoPopup from '../components/InfoPopup';
 
 interface Props {
@@ -107,6 +107,13 @@ export default function OptionalSetupPage({
             </span>
           )}
         </div>
+        {aiAnswer.trim().toLowerCase() === 'no' && (
+          <span className="ai-skip-hint" onClick={() => setShowInfo(true)}>
+            <SparkleIcon className="sparkle-icon" />
+            AI recommends 'Skip It' -- The defaults are fine
+            <InfoIcon className="info-icon" title={aiReason} />
+          </span>
+        )}
         <button className="skip-btn skip-right" onClick={onSkip}>Decide later</button>
       </div>
       <InfoPopup show={showInfo} reasoning={aiReason} onClose={() => setShowInfo(false)} />

--- a/style.css
+++ b/style.css
@@ -1270,12 +1270,47 @@ select option:checked {
   margin-left: 4px;
 }
 
+.ai-skip-hint {
+  font-size: 0.9em;
+  color: var(--bc-purple);
+  display: inline-flex;
+  align-items: center;
+  animation: slideLeft 0.5s ease-in;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+.ai-skip-hint .sparkle-icon {
+  width: 16px;
+  height: 16px;
+  margin-right: 4px;
+  color: var(--bc-purple);
+}
+
+.ai-skip-hint .info-icon {
+  width: 16px;
+  height: 16px;
+  margin-left: 4px;
+  cursor: pointer;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;
   }
   to {
     opacity: 1;
+  }
+}
+
+@keyframes slideLeft {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- show 'Skip It' suggestion between review and skip buttons
- click hint to open info popup
- animate hint sliding toward the review button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bcc9915a883229ffaeb3353b9e2a5