### PR TITLE
Fix duplicate 'AI recommends' text on optional setup page

### DIFF
--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -115,17 +115,6 @@ export default function OptionalSetupPage({
           </span>
         )}
         <button className="skip-btn skip-right" onClick={onSkip}>Decide later</button>
-        {aiAnswer.trim().toLowerCase() === 'no' && (
-          <span className="ai-skip-hint">
-            <SparkleIcon className="sparkle-icon" />
-            AI recommends 'Skip It' -- The defaults are fine
-            <InfoIcon
-              className="info-icon"
-              title={aiReason}
-              onClick={() => setShowInfo(true)}
-            />
-          </span>
-        )}
       </div>
       <InfoPopup show={showInfo} reasoning={aiReason} onClose={() => setShowInfo(false)} />
     </div>


### PR DESCRIPTION
## Summary
- remove a duplicated AI skip hint on OptionalSetupPage so 'AI recommends' only displays once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bd825573883228bcfd5388f218163