### PR TITLE
Use checkboxes for boolean values

### DIFF
--- a/src/pages/OptionalSetupPage.tsx
+++ b/src/pages/OptionalSetupPage.tsx
@@ -77,14 +77,24 @@ export default function OptionalSetupPage({
         <tbody>
           {visibleFields.map(f => {
             const val = formData[fieldKey(f.field)];
-            const displayValue =
-              f.fieldType === 'Boolean'
-                ? val === '1' || val === 1 || val === true
-                  ? 'True'
-                  : val === '0' || val === 0 || val === false
-                  ? 'False'
-                  : ''
-                : String(val ?? '');
+            const isBool = f.fieldType === 'Boolean';
+            const checked = val === '1' || val === 1 || val === true;
+            const className =
+              'grid-bool-checkbox' +
+              (val === '' || val == null ? ' empty' : '');
+            const displayValue = isBool ? (
+              <input
+                type="checkbox"
+                className={className}
+                checked={checked}
+                disabled
+                ref={el => {
+                  if (el) el.indeterminate = val === '' || val == null;
+                }}
+              />
+            ) : (
+              String(val ?? '')
+            );
             return (
               <tr key={f.field}>
                 <td>{f.question}</td>

--- a/src/utils/grid.ts
+++ b/src/utils/grid.ts
@@ -18,7 +18,15 @@ import type { TableField } from "./schema";
 // React implementation of a boolean cell renderer for ag-grid
 function BooleanCellRenderer(params: any) {
   const { value } = params;
-  const [checked, setChecked] = React.useState(value === "1");
+  const checkedVal = value === "1" || value === 1 || value === true;
+  const [checked, setChecked] = React.useState(checkedVal);
+  const ref = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    if (ref.current) {
+      ref.current.indeterminate = value === "" || value == null;
+    }
+  }, [value]);
 
   function onChange(e: React.ChangeEvent<HTMLInputElement>) {
     const isChecked = e.target.checked;
@@ -28,13 +36,14 @@ function BooleanCellRenderer(params: any) {
   }
 
   const className =
-    "grid-bool-checkbox" + (value === "" ? " empty" : "");
+    "grid-bool-checkbox" + (value === "" || value == null ? " empty" : "");
 
   return React.createElement("input", {
     type: "checkbox",
     className,
     checked,
     onChange,
+    ref,
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -1211,7 +1211,12 @@ select option:checked {
 .boolean-cell {
   justify-content: center;
 }
+.grid-bool-checkbox {
+  width: 16px;
+  height: 16px;
+}
 .grid-bool-checkbox.empty {
+  filter: grayscale(100%);
   opacity: 0.5;
 }
 


### PR DESCRIPTION
## Summary
- render Boolean values as checkboxes in optional setup review page
- improve Boolean cell renderer for grids
- add styling for Boolean checkboxes

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c181b4b8c8322ad9be861e30a1647